### PR TITLE
Emit correctly spanned errors

### DIFF
--- a/shipyard_proc/Cargo.toml
+++ b/shipyard_proc/Cargo.toml
@@ -14,3 +14,4 @@ proc-macro = true
 [dependencies]
 syn = { version = "1.0.2", features = ["full"] }
 quote = "1.0.1"
+proc-macro2 = "1.0.6"

--- a/shipyard_proc/src/lib.rs
+++ b/shipyard_proc/src/lib.rs
@@ -1,5 +1,6 @@
 extern crate proc_macro;
 use quote::quote;
+use syn::parse_quote;
 
 const MAX_TYPES: usize = 10;
 
@@ -47,9 +48,9 @@ pub fn system(
                         // transform &Entities into Entites and &mut Entities into EntitiesMut
                         if path.path.segments.last().unwrap().ident == "Entities" {
                             if reference.mutability.is_none() {
-                                **ty = quote!(::shipyard::Entities).into();
+                                **ty = parse_quote!(::shipyard::Entities);
                             } else {
-                                **ty = quote!(::shipyard::EntitiesMut).into();
+                                **ty = parse_quote!(::shipyard::EntitiesMut);
                             }
                         } else {
                             reference.lifetime = reference.lifetime.clone().or(Some(syn::Lifetime::new(
@@ -111,11 +112,11 @@ pub fn system(
     while data.len() > MAX_TYPES {
         for i in 0..(data.len() / MAX_TYPES) {
             let ten = &data[(i * MAX_TYPES)..((i + 1) * MAX_TYPES)];
-            *data[i] = quote!((#(#ten,)*)).into();
+            *data[i] = parse_quote!((#(#ten,)*));
             data.drain((i + 1)..((i + 1) * MAX_TYPES));
 
             let ten = &binding[i..(i + 10)];
-            binding[i] = quote!((#(#ten,)*)).into();
+            binding[i] = parse_quote!((#(#ten,)*));
             binding.drain((i + 1)..((i + 1) * MAX_TYPES));
         }
     }

--- a/shipyard_proc/src/lib.rs
+++ b/shipyard_proc/src/lib.rs
@@ -52,17 +52,11 @@ pub fn system(
                             } else {
                                 **ty = parse_quote!(::shipyard::EntitiesMut);
                             }
-                        } else {
-                            reference.lifetime = reference.lifetime.clone().or(Some(syn::Lifetime::new(
-                                "'a",
-                                proc_macro::Span::call_site().into(),
-                            )));
+                        } else if reference.lifetime.is_none() {
+                            reference.lifetime = parse_quote!('a);
                         }
-                    } else {
-                        reference.lifetime = reference.lifetime.clone().or(Some(syn::Lifetime::new(
-                            "'a",
-                            proc_macro::Span::call_site().into(),
-                        )));
+                    } else if reference.lifetime.is_none() {
+                        reference.lifetime = parse_quote!('a);
                     }
                 }
                 syn::Type::Path(ref mut path) => {
@@ -75,10 +69,9 @@ pub fn system(
                             let arg = inner_type.args.iter_mut().next().unwrap();
                             if let syn::GenericArgument::Type(inner_type) = arg {
                                 if let syn::Type::Reference(reference) = inner_type {
-                                    reference.lifetime = reference.lifetime.clone().or(Some(syn::Lifetime::new(
-                                        "'a",
-                                        proc_macro::Span::call_site().into(),
-                                    )));
+                                    if reference.lifetime.is_none() {
+                                        reference.lifetime = parse_quote!('a);
+                                    }
                                 } else {
                                     panic!("Not will only work with component storages refered by &T or &mut T.")
                                 }

--- a/shipyard_proc/src/lib.rs
+++ b/shipyard_proc/src/lib.rs
@@ -112,13 +112,13 @@ fn expand_system(name: syn::Ident, mut run: syn::ItemFn) -> Result<TokenStream> 
                 _ => {
                     return Err(Error::new_spanned(
                         ty,
-                        "A system will only accept a type of this list:\n\n\
-                            \t\t\t&T for an immutable reference to T storage\n\
-                            \t\t\t&mut T for a mutable reference to T storage\n\
-                            \t\t\t&Entities for an immutable reference to the entity storage\n\
-                            \t\t\t&mut EntitiesMut for a mutable reference to the entity storage\n\
-                            \t\t\tAllStorages for a mutable reference to the storage of all components\n\
-                            \t\t\tThreadPool for an immutable reference to the rayon::ThreadPool used by the World",
+                        "A system will only accept a type of this list:\n\
+                            \t\t- &T for an immutable reference to T storage\n\
+                            \t\t- &mut T for a mutable reference to T storage\n\
+                            \t\t- &Entities for an immutable reference to the entity storage\n\
+                            \t\t- &mut EntitiesMut for a mutable reference to the entity storage\n\
+                            \t\t- AllStorages for a mutable reference to the storage of all components\n\
+                            \t\t- ThreadPool for an immutable reference to the rayon::ThreadPool used by the World",
                     ));
                 }
             }

--- a/tests/derive/generic_lifetime.rs
+++ b/tests/derive/generic_lifetime.rs
@@ -2,3 +2,5 @@ use shipyard::*;
 
 #[system(Test)]
 fn run<'a>() {}
+
+fn main() {}

--- a/tests/derive/generic_lifetime.stderr
+++ b/tests/derive/generic_lifetime.stderr
@@ -1,7 +1,5 @@
-error: custom attribute panicked
- --> $DIR/generic_lifetime.rs:3:1
+error: run should not take generic arguments
+ --> $DIR/generic_lifetime.rs:4:7
   |
-3 | #[system(Test)]
-  | ^^^^^^^^^^^^^^^
-  |
-  = help: message: run should not take generic arguments nor where clause.
+4 | fn run<'a>() {}
+  |       ^^^^

--- a/tests/derive/generic_type.rs
+++ b/tests/derive/generic_type.rs
@@ -2,3 +2,5 @@ use shipyard::*;
 
 #[system(Test)]
 fn run<T>() {}
+
+fn main() {}

--- a/tests/derive/generic_type.stderr
+++ b/tests/derive/generic_type.stderr
@@ -1,7 +1,5 @@
-error: custom attribute panicked
- --> $DIR/generic_type.rs:3:1
+error: run should not take generic arguments
+ --> $DIR/generic_type.rs:4:7
   |
-3 | #[system(Test)]
-  | ^^^^^^^^^^^^^^^
-  |
-  = help: message: run should not take generic arguments nor where clause.
+4 | fn run<T>() {}
+  |       ^^^

--- a/tests/derive/not_entities.rs
+++ b/tests/derive/not_entities.rs
@@ -2,3 +2,5 @@ use shipyard::*;
 
 #[system(Test)]
 fn run(_: Not<Entities>) {}
+
+fn main() {}

--- a/tests/derive/not_entities.stderr
+++ b/tests/derive/not_entities.stderr
@@ -1,7 +1,5 @@
-error: custom attribute panicked
- --> $DIR/not_entities.rs:3:1
+error: Not will only work with component storages refered by &T or &mut T
+ --> $DIR/not_entities.rs:4:15
   |
-3 | #[system(Test)]
-  | ^^^^^^^^^^^^^^^
-  |
-  = help: message: Not will only work with component storages refered by &T or &mut T.
+4 | fn run(_: Not<Entities>) {}
+  |               ^^^^^^^^

--- a/tests/derive/not_run.rs
+++ b/tests/derive/not_run.rs
@@ -2,3 +2,5 @@ use shipyard::*;
 
 #[system(Test)]
 fn test() {}
+
+fn main() {}

--- a/tests/derive/not_run.stderr
+++ b/tests/derive/not_run.stderr
@@ -1,7 +1,5 @@
-error: custom attribute panicked
+error: Systems have only one method: run
  --> $DIR/not_run.rs:3:1
   |
 3 | #[system(Test)]
   | ^^^^^^^^^^^^^^^
-  |
-  = help: message: Systems have only one method: run.

--- a/tests/derive/return_something.rs
+++ b/tests/derive/return_something.rs
@@ -2,3 +2,5 @@ use shipyard::*;
 
 #[system(Test)]
 fn run() -> usize { 0 }
+
+fn main() {}

--- a/tests/derive/return_something.stderr
+++ b/tests/derive/return_something.stderr
@@ -1,7 +1,5 @@
-error: custom attribute panicked
- --> $DIR/return_something.rs:3:1
+error: run should not return anything
+ --> $DIR/return_something.rs:4:10
   |
-3 | #[system(Test)]
-  | ^^^^^^^^^^^^^^^
-  |
-  = help: message: run should not return anything.
+4 | fn run() -> usize { 0 }
+  |          ^^^^^^^^

--- a/tests/derive/where.stderr
+++ b/tests/derive/where.stderr
@@ -1,7 +1,5 @@
-error: custom attribute panicked
- --> $DIR/where.rs:3:1
+error: run should not take a where clause
+ --> $DIR/where.rs:4:19
   |
-3 | #[system(Test)]
-  | ^^^^^^^^^^^^^^^
-  |
-  = help: message: run should not take generic arguments nor where clause.
+4 | fn run(_: &usize) where usize: Debug {}
+  |                   ^^^^^^^^^^^^^^^^^^

--- a/tests/derive/wrong_type.rs
+++ b/tests/derive/wrong_type.rs
@@ -2,3 +2,5 @@ use shipyard::*;
 
 #[system(Test)]
 fn run(_: fn()) {}
+
+fn main() {}

--- a/tests/derive/wrong_type.stderr
+++ b/tests/derive/wrong_type.stderr
@@ -1,11 +1,10 @@
 error: A system will only accept a type of this list:
-
-            &T for an immutable reference to T storage
-            &mut T for a mutable reference to T storage
-            &Entities for an immutable reference to the entity storage
-            &mut EntitiesMut for a mutable reference to the entity storage
-            AllStorages for a mutable reference to the storage of all components
-            ThreadPool for an immutable reference to the rayon::ThreadPool used by the World
+        - &T for an immutable reference to T storage
+        - &mut T for a mutable reference to T storage
+        - &Entities for an immutable reference to the entity storage
+        - &mut EntitiesMut for a mutable reference to the entity storage
+        - AllStorages for a mutable reference to the storage of all components
+        - ThreadPool for an immutable reference to the rayon::ThreadPool used by the World
  --> $DIR/wrong_type.rs:4:11
   |
 4 | fn run(_: fn()) {}

--- a/tests/derive/wrong_type.stderr
+++ b/tests/derive/wrong_type.stderr
@@ -1,14 +1,12 @@
-error: custom attribute panicked
- --> $DIR/wrong_type.rs:3:1
+error: A system will only accept a type of this list:
+
+            &T for an immutable reference to T storage
+            &mut T for a mutable reference to T storage
+            &Entities for an immutable reference to the entity storage
+            &mut EntitiesMut for a mutable reference to the entity storage
+            AllStorages for a mutable reference to the storage of all components
+            ThreadPool for an immutable reference to the rayon::ThreadPool used by the World
+ --> $DIR/wrong_type.rs:4:11
   |
-3 | #[system(Test)]
-  | ^^^^^^^^^^^^^^^
-  |
-  = help: message: A system will only accept a type of this list:
-          
-                      &T for an immutable reference to T storage
-                      &mut T for a mutable reference to T storage
-                      &Entities for an immutable reference to the entity storage
-                      &mut EntitiesMut for a mutable reference to the entity storage
-                      AllStorages for a mutable reference to the storage of all components
-                      ThreadPool for an immutable reference to the rayon::ThreadPool used by the World
+4 | fn run(_: fn()) {}
+  |           ^^^^


### PR DESCRIPTION
#### Before:

```console
error: custom attribute panicked
 --> $DIR/where.rs:3:1
  |
3 | #[system(Test)]
  | ^^^^^^^^^^^^^^^
  |
  = help: message: run should not take generic arguments nor where clause.
```

```console
error: custom attribute panicked
 --> $DIR/return_something.rs:3:1
  |
3 | #[system(Test)]
  | ^^^^^^^^^^^^^^^
  |
  = help: message: run should not return anything.
```

```console
error: custom attribute panicked
 --> $DIR/not_entities.rs:3:1
  |
3 | #[system(Test)]
  | ^^^^^^^^^^^^^^^
  |
  = help: message: Not will only work with component storages refered by &T or &mut T.
```

#### After:

```console
error: run should not take a where clause
 --> $DIR/where.rs:4:19
  |
4 | fn run(_: &usize) where usize: Debug {}
  |                   ^^^^^^^^^^^^^^^^^^
```

```console
error: run should not return anything
 --> $DIR/return_something.rs:4:10
  |
4 | fn run() -> usize { 0 }
  |          ^^^^^^^^
```

```console
error: Not will only work with component storages refered by &T or &mut T
 --> $DIR/not_entities.rs:4:15
  |
4 | fn run(_: Not<Entities>) {}
  |               ^^^^^^^^
```