### PR TITLE
Build docs with all features on docs.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,3 +32,7 @@ std = []
 [dev-dependencies]
 trybuild = "^1"
 serde_json = "^1"
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/src/iter/iterators/loose/par_multiple.rs
+++ b/src/iter/iterators/loose/par_multiple.rs
@@ -12,6 +12,7 @@ macro_rules! impl_iterators {
         #[doc = "Loose parallel iterator over"]
         #[doc = $number]
         #[doc = "components."]
+        #[cfg_attr(docsrs, doc(cfg(feature = "parallel")))]
         pub struct $loose<$($type: IntoAbstract),+>($seq<$($type),+>);
 
         impl<$($type: IntoAbstract),+> From<$seq<$($type),+>> for $loose<$($type),+> {

--- a/src/iter/iterators/non_packed/par_multiple.rs
+++ b/src/iter/iterators/non_packed/par_multiple.rs
@@ -14,6 +14,7 @@ macro_rules! impl_iterators {
         #[doc = "Non packed parallel iterator over"]
         #[doc = $number]
         #[doc = "components."]
+        #[cfg_attr(docsrs, doc(cfg(feature = "parallel")))]
         pub struct $non_packed<$($type: IntoAbstract),+>($seq<$($type),+>);
 
         impl<$($type: IntoAbstract),+> From<$seq<$($type),+>> for $non_packed<$($type),+> {

--- a/src/iter/iterators/tight/par_multiple.rs
+++ b/src/iter/iterators/tight/par_multiple.rs
@@ -13,6 +13,7 @@ macro_rules! impl_iterators {
         #[doc = $number]
         #[doc = "components.  
 Tight iterators are fast but are limited to components tightly packed together."]
+        #[cfg_attr(docsrs, doc(cfg(feature = "parallel")))]
         pub struct $tight<$($type: IntoAbstract),+>($seq<$($type),+>);
 
         impl<$($type: IntoAbstract),+> From<$seq<$($type),+>> for $tight<$($type),+> {

--- a/src/iter/iterators/tight/par_single.rs
+++ b/src/iter/iterators/tight/par_single.rs
@@ -3,6 +3,7 @@ use rayon::iter::plumbing::{bridge, Consumer, ProducerCallback, UnindexedConsume
 use rayon::iter::{IndexedParallelIterator, ParallelIterator};
 
 /// Tight parallel iterator over a single component.
+#[cfg_attr(docsrs, doc(cfg(feature = "parallel")))]
 pub struct ParTight1<T: IntoAbstract>(Tight1<T>);
 
 impl<T: IntoAbstract> From<Tight1<T>> for ParTight1<T> {

--- a/src/iter/iterators/update/par_single.rs
+++ b/src/iter/iterators/update/par_single.rs
@@ -3,6 +3,7 @@ use rayon::iter::plumbing::{bridge, Consumer, Producer, ProducerCallback, Uninde
 use rayon::iter::{IndexedParallelIterator, ParallelIterator};
 
 /// Update parallel iterator over a single component.
+#[cfg_attr(docsrs, doc(cfg(feature = "parallel")))]
 pub struct ParUpdate1<T: IntoAbstract> {
     data: T::AbsView,
     current: usize,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,6 +128,7 @@
 #![deny(trivial_numeric_casts)]
 #![deny(unused_qualifications)]
 #![cfg_attr(not(any(feature = "std", test)), no_std)]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 #[macro_use]
 extern crate alloc;
@@ -156,6 +157,7 @@ pub use world::World;
 
 /// Type used to borrow the rayon::ThreadPool inside `World`.
 #[cfg(feature = "parallel")]
+#[cfg_attr(docsrs, doc(cfg(feature = "parallel")))]
 pub struct ThreadPool;
 
 /// Type used to access the value of a unique storage.
@@ -173,12 +175,15 @@ pub struct Unique<T: ?Sized>(T);
 
 /// Type used to access `!Send` storages.
 #[cfg(feature = "non_send")]
+#[cfg_attr(docsrs, doc(cfg(feature = "non_send")))]
 pub struct NonSend<T: ?Sized>(T);
 
 /// Type used to access `!Sync` storages.
 #[cfg(feature = "non_sync")]
+#[cfg_attr(docsrs, doc(cfg(feature = "non_sync")))]
 pub struct NonSync<T: ?Sized>(T);
 
 /// Type used to access `!Send + !Sync` storages.
 #[cfg(all(feature = "non_send", feature = "non_sync"))]
+#[cfg_attr(docsrs, doc(cfg(all(feature = "non_send", feature = "non_sync"))))]
 pub struct NonSendSync<T: ?Sized>(T);

--- a/src/storage/all/mod.rs
+++ b/src/storage/all/mod.rs
@@ -419,11 +419,19 @@ You can use:
 * `&mut T` for an exclusive access to `T` storage
 * [Entities] for a shared access to the entity storage
 * [EntitiesMut] for an exclusive reference to the entity storage
-* [AllStorages] for an exclusive access to the storage of all components
+* [AllStorages] for an exclusive access to the storage of all components, ⚠️ can't coexist with any other storage borrow
 * [Unique]<&T> for a shared access to a `T` unique storage
 * [Unique]<&mut T> for an exclusive access to a `T` unique storage"]
     #[cfg_attr(
-        feature = "parallel",
+        all(feature = "parallel", docsrs),
+        doc = "* <span style=\"display: table;color: #2f2f2f;background-color: #C4ECFF;border-width: 1px;border-style: solid;border-color: #7BA5DB;padding: 3px;margin-bottom: 5px; font-size: 90%\">This is supported on <strong><code style=\"background-color: #C4ECFF\">feature=\"parallel\"</code></strong> only:</span>"
+    )]
+    #[cfg_attr(
+        all(feature = "parallel", docsrs),
+        doc = "    * [ThreadPool] for a shared access to the `ThreadPool` used by the [World]"
+    )]
+    #[cfg_attr(
+        all(feature = "parallel", not(docsrs)),
         doc = "* [ThreadPool] for a shared access to the `ThreadPool` used by the [World]"
     )]
     #[cfg_attr(
@@ -431,7 +439,17 @@ You can use:
         doc = "* ThreadPool: must activate the *parallel* feature"
     )]
     #[cfg_attr(
-        feature = "non_send",
+        all(feature = "non_send", docsrs),
+        doc = "* <span style=\"display: table;color: #2f2f2f;background-color: #C4ECFF;border-width: 1px;border-style: solid;border-color: #7BA5DB;padding: 3px;margin-bottom: 5px; font-size: 90%\">This is supported on <strong><code style=\"background-color: #C4ECFF\">feature=\"non_send\"</code></strong> only:</span>"
+    )]
+    #[cfg_attr(
+        all(feature = "non_send", docsrs),
+        doc = "    * [NonSend]<&T> for a shared access to a `T` storage where `T` isn't `Send`
+    * [NonSend]<&mut T> for an exclusive access to a `T` storage where `T` isn't `Send`  
+[Unique] and [NonSend] can be used together to access a `!Send` unique storage."
+    )]
+    #[cfg_attr(
+        all(feature = "non_send", not(docsrs)),
         doc = "* [NonSend]<&T> for a shared access to a `T` storage where `T` isn't `Send`
 * [NonSend]<&mut T> for an exclusive access to a `T` storage where `T` isn't `Send`  
 [Unique] and [NonSend] can be used together to access a `!Send` unique storage."
@@ -441,7 +459,17 @@ You can use:
         doc = "* NonSend: must activate the *non_send* feature"
     )]
     #[cfg_attr(
-        feature = "non_sync",
+        all(feature = "non_sync", docsrs),
+        doc = "* <span style=\"display: table;color: #2f2f2f;background-color: #C4ECFF;border-width: 1px;border-style: solid;border-color: #7BA5DB;padding: 3px;margin-bottom: 5px; font-size: 90%\">This is supported on <strong><code style=\"background-color: #C4ECFF\">feature=\"non_sync\"</code></strong> only:</span>"
+    )]
+    #[cfg_attr(
+        all(feature = "non_sync", docsrs),
+        doc = "    * [NonSync]<&T> for a shared access to a `T` storage where `T` isn't `Sync`
+    * [NonSync]<&mut T> for an exclusive access to a `T` storage where `T` isn't `Sync`  
+[Unique] and [NonSync] can be used together to access a `!Sync` unique storage."
+    )]
+    #[cfg_attr(
+        all(feature = "non_sync", not(docsrs)),
         doc = "* [NonSync]<&T> for a shared access to a `T` storage where `T` isn't `Sync`
 * [NonSync]<&mut T> for an exclusive access to a `T` storage where `T` isn't `Sync`  
 [Unique] and [NonSync] can be used together to access a `!Sync` unique storage."
@@ -451,7 +479,17 @@ You can use:
         doc = "* NonSync: must activate the *non_sync* feature"
     )]
     #[cfg_attr(
-        all(feature = "non_send", feature = "non_sync"),
+        all(feature = "non_sync", docsrs),
+        doc = "* <span style=\"display: table;color: #2f2f2f;background-color: #C4ECFF;border-width: 1px;border-style: solid;border-color: #7BA5DB;padding: 3px;margin-bottom: 5px; font-size: 90%\">This is supported on <strong><code style=\"background-color: #C4ECFF\">feature=\"non_send\"</code> and <code style=\"background-color: #C4ECFF\">feature=\"non_sync\"</code></strong> only:</span>"
+    )]
+    #[cfg_attr(
+        all(feature = "non_send", feature = "non_sync", docsrs),
+        doc = "    * [NonSendSync]<&T> for a shared access to a `T` storage where `T` isn't `Send` nor `Sync`
+    * [NonSendSync]<&mut T> for an exclusive access to a `T` storage where `T` isn't `Send` nor `Sync`  
+[Unique] and [NonSendSync] can be used together to access a `!Send + !Sync` unique storage."
+    )]
+    #[cfg_attr(
+        all(feature = "non_send", feature = "non_sync", not(docsrs)),
         doc = "* [NonSendSync]<&T> for a shared access to a `T` storage where `T` isn't `Send` nor `Sync`
 * [NonSendSync]<&mut T> for an exclusive access to a `T` storage where `T` isn't `Send` nor `Sync`  
 [Unique] and [NonSendSync] can be used together to access a `!Send + !Sync` unique storage."
@@ -492,11 +530,19 @@ You can use:
 * `&mut T` for an exclusive access to `T` storage
 * [Entities] for a shared access to the entity storage
 * [EntitiesMut] for an exclusive reference to the entity storage
-* [AllStorages] for an exclusive access to the storage of all components
+* [AllStorages] for an exclusive access to the storage of all components, ⚠️ can't coexist with any other storage borrow
 * [Unique]<&T> for a shared access to a `T` unique storage
 * [Unique]<&mut T> for an exclusive access to a `T` unique storage"]
     #[cfg_attr(
-        feature = "parallel",
+        all(feature = "parallel", docsrs),
+        doc = "* <span style=\"display: table;color: #2f2f2f;background-color: #C4ECFF;border-width: 1px;border-style: solid;border-color: #7BA5DB;padding: 3px;margin-bottom: 5px; font-size: 90%\">This is supported on <strong><code style=\"background-color: #C4ECFF\">feature=\"parallel\"</code></strong> only:</span>"
+    )]
+    #[cfg_attr(
+        all(feature = "parallel", docsrs),
+        doc = "    * [ThreadPool] for a shared access to the `ThreadPool` used by the [World]"
+    )]
+    #[cfg_attr(
+        all(feature = "parallel", not(docsrs)),
         doc = "* [ThreadPool] for a shared access to the `ThreadPool` used by the [World]"
     )]
     #[cfg_attr(
@@ -504,7 +550,17 @@ You can use:
         doc = "* ThreadPool: must activate the *parallel* feature"
     )]
     #[cfg_attr(
-        feature = "non_send",
+        all(feature = "non_send", docsrs),
+        doc = "* <span style=\"display: table;color: #2f2f2f;background-color: #C4ECFF;border-width: 1px;border-style: solid;border-color: #7BA5DB;padding: 3px;margin-bottom: 5px; font-size: 90%\">This is supported on <strong><code style=\"background-color: #C4ECFF\">feature=\"non_send\"</code></strong> only:</span>"
+    )]
+    #[cfg_attr(
+        all(feature = "non_send", docsrs),
+        doc = "    * [NonSend]<&T> for a shared access to a `T` storage where `T` isn't `Send`
+    * [NonSend]<&mut T> for an exclusive access to a `T` storage where `T` isn't `Send`  
+[Unique] and [NonSend] can be used together to access a `!Send` unique storage."
+    )]
+    #[cfg_attr(
+        all(feature = "non_send", not(docsrs)),
         doc = "* [NonSend]<&T> for a shared access to a `T` storage where `T` isn't `Send`
 * [NonSend]<&mut T> for an exclusive access to a `T` storage where `T` isn't `Send`  
 [Unique] and [NonSend] can be used together to access a `!Send` unique storage."
@@ -514,7 +570,17 @@ You can use:
         doc = "* NonSend: must activate the *non_send* feature"
     )]
     #[cfg_attr(
-        feature = "non_sync",
+        all(feature = "non_sync", docsrs),
+        doc = "* <span style=\"display: table;color: #2f2f2f;background-color: #C4ECFF;border-width: 1px;border-style: solid;border-color: #7BA5DB;padding: 3px;margin-bottom: 5px; font-size: 90%\">This is supported on <strong><code style=\"background-color: #C4ECFF\">feature=\"non_sync\"</code></strong> only:</span>"
+    )]
+    #[cfg_attr(
+        all(feature = "non_sync", docsrs),
+        doc = "    * [NonSync]<&T> for a shared access to a `T` storage where `T` isn't `Sync`
+    * [NonSync]<&mut T> for an exclusive access to a `T` storage where `T` isn't `Sync`  
+[Unique] and [NonSync] can be used together to access a `!Sync` unique storage."
+    )]
+    #[cfg_attr(
+        all(feature = "non_sync", not(docsrs)),
         doc = "* [NonSync]<&T> for a shared access to a `T` storage where `T` isn't `Sync`
 * [NonSync]<&mut T> for an exclusive access to a `T` storage where `T` isn't `Sync`  
 [Unique] and [NonSync] can be used together to access a `!Sync` unique storage."
@@ -524,7 +590,17 @@ You can use:
         doc = "* NonSync: must activate the *non_sync* feature"
     )]
     #[cfg_attr(
-        all(feature = "non_send", feature = "non_sync"),
+        all(feature = "non_sync", docsrs),
+        doc = "* <span style=\"display: table;color: #2f2f2f;background-color: #C4ECFF;border-width: 1px;border-style: solid;border-color: #7BA5DB;padding: 3px;margin-bottom: 5px; font-size: 90%\">This is supported on <strong><code style=\"background-color: #C4ECFF\">feature=\"non_send\"</code> and <code style=\"background-color: #C4ECFF\">feature=\"non_sync\"</code></strong> only:</span>"
+    )]
+    #[cfg_attr(
+        all(feature = "non_send", feature = "non_sync", docsrs),
+        doc = "    * [NonSendSync]<&T> for a shared access to a `T` storage where `T` isn't `Send` nor `Sync`
+    * [NonSendSync]<&mut T> for an exclusive access to a `T` storage where `T` isn't `Send` nor `Sync`  
+[Unique] and [NonSendSync] can be used together to access a `!Send + !Sync` unique storage."
+    )]
+    #[cfg_attr(
+        all(feature = "non_send", feature = "non_sync", not(docsrs)),
         doc = "* [NonSendSync]<&T> for a shared access to a `T` storage where `T` isn't `Send` nor `Sync`
 * [NonSendSync]<&mut T> for an exclusive access to a `T` storage where `T` isn't `Send` nor `Sync`  
 [Unique] and [NonSendSync] can be used together to access a `!Send + !Sync` unique storage."

--- a/src/world/mod.rs
+++ b/src/world/mod.rs
@@ -189,11 +189,19 @@ You can use:
 * `&mut T` for an exclusive access to `T` storage
 * [Entities] for a shared access to the entity storage
 * [EntitiesMut] for an exclusive reference to the entity storage
-* [AllStorages] for an exclusive access to the storage of all components
+* [AllStorages] for an exclusive access to the storage of all components, ⚠️ can't coexist with any other storage borrow
 * [Unique]<&T> for a shared access to a `T` unique storage
 * [Unique]<&mut T> for an exclusive access to a `T` unique storage"]
     #[cfg_attr(
-        feature = "parallel",
+        all(feature = "parallel", docsrs),
+        doc = "* <span style=\"display: table;color: #2f2f2f;background-color: #C4ECFF;border-width: 1px;border-style: solid;border-color: #7BA5DB;padding: 3px;margin-bottom: 5px; font-size: 90%\">This is supported on <strong><code style=\"background-color: #C4ECFF\">feature=\"parallel\"</code></strong> only:</span>"
+    )]
+    #[cfg_attr(
+        all(feature = "parallel", docsrs),
+        doc = "    * [ThreadPool] for a shared access to the `ThreadPool` used by the [World]"
+    )]
+    #[cfg_attr(
+        all(feature = "parallel", not(docsrs)),
         doc = "* [ThreadPool] for a shared access to the `ThreadPool` used by the [World]"
     )]
     #[cfg_attr(
@@ -201,7 +209,17 @@ You can use:
         doc = "* ThreadPool: must activate the *parallel* feature"
     )]
     #[cfg_attr(
-        feature = "non_send",
+        all(feature = "non_send", docsrs),
+        doc = "* <span style=\"display: table;color: #2f2f2f;background-color: #C4ECFF;border-width: 1px;border-style: solid;border-color: #7BA5DB;padding: 3px;margin-bottom: 5px; font-size: 90%\">This is supported on <strong><code style=\"background-color: #C4ECFF\">feature=\"non_send\"</code></strong> only:</span>"
+    )]
+    #[cfg_attr(
+        all(feature = "non_send", docsrs),
+        doc = "    * [NonSend]<&T> for a shared access to a `T` storage where `T` isn't `Send`
+    * [NonSend]<&mut T> for an exclusive access to a `T` storage where `T` isn't `Send`  
+[Unique] and [NonSend] can be used together to access a `!Send` unique storage."
+    )]
+    #[cfg_attr(
+        all(feature = "non_send", not(docsrs)),
         doc = "* [NonSend]<&T> for a shared access to a `T` storage where `T` isn't `Send`
 * [NonSend]<&mut T> for an exclusive access to a `T` storage where `T` isn't `Send`  
 [Unique] and [NonSend] can be used together to access a `!Send` unique storage."
@@ -211,7 +229,17 @@ You can use:
         doc = "* NonSend: must activate the *non_send* feature"
     )]
     #[cfg_attr(
-        feature = "non_sync",
+        all(feature = "non_sync", docsrs),
+        doc = "* <span style=\"display: table;color: #2f2f2f;background-color: #C4ECFF;border-width: 1px;border-style: solid;border-color: #7BA5DB;padding: 3px;margin-bottom: 5px; font-size: 90%\">This is supported on <strong><code style=\"background-color: #C4ECFF\">feature=\"non_sync\"</code></strong> only:</span>"
+    )]
+    #[cfg_attr(
+        all(feature = "non_sync", docsrs),
+        doc = "    * [NonSync]<&T> for a shared access to a `T` storage where `T` isn't `Sync`
+    * [NonSync]<&mut T> for an exclusive access to a `T` storage where `T` isn't `Sync`  
+[Unique] and [NonSync] can be used together to access a `!Sync` unique storage."
+    )]
+    #[cfg_attr(
+        all(feature = "non_sync", not(docsrs)),
         doc = "* [NonSync]<&T> for a shared access to a `T` storage where `T` isn't `Sync`
 * [NonSync]<&mut T> for an exclusive access to a `T` storage where `T` isn't `Sync`  
 [Unique] and [NonSync] can be used together to access a `!Sync` unique storage."
@@ -221,7 +249,17 @@ You can use:
         doc = "* NonSync: must activate the *non_sync* feature"
     )]
     #[cfg_attr(
-        all(feature = "non_send", feature = "non_sync"),
+        all(feature = "non_sync", docsrs),
+        doc = "* <span style=\"display: table;color: #2f2f2f;background-color: #C4ECFF;border-width: 1px;border-style: solid;border-color: #7BA5DB;padding: 3px;margin-bottom: 5px; font-size: 90%\">This is supported on <strong><code style=\"background-color: #C4ECFF\">feature=\"non_send\"</code> and <code style=\"background-color: #C4ECFF\">feature=\"non_sync\"</code></strong> only:</span>"
+    )]
+    #[cfg_attr(
+        all(feature = "non_send", feature = "non_sync", docsrs),
+        doc = "    * [NonSendSync]<&T> for a shared access to a `T` storage where `T` isn't `Send` nor `Sync`
+    * [NonSendSync]<&mut T> for an exclusive access to a `T` storage where `T` isn't `Send` nor `Sync`  
+[Unique] and [NonSendSync] can be used together to access a `!Send + !Sync` unique storage."
+    )]
+    #[cfg_attr(
+        all(feature = "non_send", feature = "non_sync", not(docsrs)),
         doc = "* [NonSendSync]<&T> for a shared access to a `T` storage where `T` isn't `Send` nor `Sync`
 * [NonSendSync]<&mut T> for an exclusive access to a `T` storage where `T` isn't `Send` nor `Sync`  
 [Unique] and [NonSendSync] can be used together to access a `!Send + !Sync` unique storage."
@@ -270,11 +308,19 @@ You can use:
 * `&mut T` for an exclusive access to `T` storage
 * [Entities] for a shared access to the entity storage
 * [EntitiesMut] for an exclusive reference to the entity storage
-* [AllStorages] for an exclusive access to the storage of all components
+* [AllStorages] for an exclusive access to the storage of all components, ⚠️ can't coexist with any other storage borrow
 * [Unique]<&T> for a shared access to a `T` unique storage
 * [Unique]<&mut T> for an exclusive access to a `T` unique storage"]
     #[cfg_attr(
-        feature = "parallel",
+        all(feature = "parallel", docsrs),
+        doc = "* <span style=\"display: table;color: #2f2f2f;background-color: #C4ECFF;border-width: 1px;border-style: solid;border-color: #7BA5DB;padding: 3px;margin-bottom: 5px; font-size: 90%\">This is supported on <strong><code style=\"background-color: #C4ECFF\">feature=\"parallel\"</code></strong> only:</span>"
+    )]
+    #[cfg_attr(
+        all(feature = "parallel", docsrs),
+        doc = "    * [ThreadPool] for a shared access to the `ThreadPool` used by the [World]"
+    )]
+    #[cfg_attr(
+        all(feature = "parallel", not(docsrs)),
         doc = "* [ThreadPool] for a shared access to the `ThreadPool` used by the [World]"
     )]
     #[cfg_attr(
@@ -282,7 +328,17 @@ You can use:
         doc = "* ThreadPool: must activate the *parallel* feature"
     )]
     #[cfg_attr(
-        feature = "non_send",
+        all(feature = "non_send", docsrs),
+        doc = "* <span style=\"display: table;color: #2f2f2f;background-color: #C4ECFF;border-width: 1px;border-style: solid;border-color: #7BA5DB;padding: 3px;margin-bottom: 5px; font-size: 90%\">This is supported on <strong><code style=\"background-color: #C4ECFF\">feature=\"non_send\"</code></strong> only:</span>"
+    )]
+    #[cfg_attr(
+        all(feature = "non_send", docsrs),
+        doc = "    * [NonSend]<&T> for a shared access to a `T` storage where `T` isn't `Send`
+    * [NonSend]<&mut T> for an exclusive access to a `T` storage where `T` isn't `Send`  
+[Unique] and [NonSend] can be used together to access a `!Send` unique storage."
+    )]
+    #[cfg_attr(
+        all(feature = "non_send", not(docsrs)),
         doc = "* [NonSend]<&T> for a shared access to a `T` storage where `T` isn't `Send`
 * [NonSend]<&mut T> for an exclusive access to a `T` storage where `T` isn't `Send`  
 [Unique] and [NonSend] can be used together to access a `!Send` unique storage."
@@ -292,7 +348,17 @@ You can use:
         doc = "* NonSend: must activate the *non_send* feature"
     )]
     #[cfg_attr(
-        feature = "non_sync",
+        all(feature = "non_sync", docsrs),
+        doc = "* <span style=\"display: table;color: #2f2f2f;background-color: #C4ECFF;border-width: 1px;border-style: solid;border-color: #7BA5DB;padding: 3px;margin-bottom: 5px; font-size: 90%\">This is supported on <strong><code style=\"background-color: #C4ECFF\">feature=\"non_sync\"</code></strong> only:</span>"
+    )]
+    #[cfg_attr(
+        all(feature = "non_sync", docsrs),
+        doc = "    * [NonSync]<&T> for a shared access to a `T` storage where `T` isn't `Sync`
+    * [NonSync]<&mut T> for an exclusive access to a `T` storage where `T` isn't `Sync`  
+[Unique] and [NonSync] can be used together to access a `!Sync` unique storage."
+    )]
+    #[cfg_attr(
+        all(feature = "non_sync", not(docsrs)),
         doc = "* [NonSync]<&T> for a shared access to a `T` storage where `T` isn't `Sync`
 * [NonSync]<&mut T> for an exclusive access to a `T` storage where `T` isn't `Sync`  
 [Unique] and [NonSync] can be used together to access a `!Sync` unique storage."
@@ -302,7 +368,17 @@ You can use:
         doc = "* NonSync: must activate the *non_sync* feature"
     )]
     #[cfg_attr(
-        all(feature = "non_send", feature = "non_sync"),
+        all(feature = "non_sync", docsrs),
+        doc = "* <span style=\"display: table;color: #2f2f2f;background-color: #C4ECFF;border-width: 1px;border-style: solid;border-color: #7BA5DB;padding: 3px;margin-bottom: 5px; font-size: 90%\">This is supported on <strong><code style=\"background-color: #C4ECFF\">feature=\"non_send\"</code> and <code style=\"background-color: #C4ECFF\">feature=\"non_sync\"</code></strong> only:</span>"
+    )]
+    #[cfg_attr(
+        all(feature = "non_send", feature = "non_sync", docsrs),
+        doc = "    * [NonSendSync]<&T> for a shared access to a `T` storage where `T` isn't `Send` nor `Sync`
+    * [NonSendSync]<&mut T> for an exclusive access to a `T` storage where `T` isn't `Send` nor `Sync`  
+[Unique] and [NonSendSync] can be used together to access a `!Send + !Sync` unique storage."
+    )]
+    #[cfg_attr(
+        all(feature = "non_send", feature = "non_sync", not(docsrs)),
         doc = "* [NonSendSync]<&T> for a shared access to a `T` storage where `T` isn't `Send` nor `Sync`
 * [NonSendSync]<&mut T> for an exclusive access to a `T` storage where `T` isn't `Send` nor `Sync`  
 [Unique] and [NonSendSync] can be used together to access a `!Send + !Sync` unique storage."
@@ -342,11 +418,19 @@ You can use:
 * `&mut T` for an exclusive access to `T` storage
 * [Entities] for a shared access to the entity storage
 * [EntitiesMut] for an exclusive reference to the entity storage
-* [AllStorages] for an exclusive access to the storage of all components
+* [AllStorages] for an exclusive access to the storage of all components, ⚠️ can't coexist with any other storage borrow
 * [Unique]<&T> for a shared access to a `T` unique storage
 * [Unique]<&mut T> for an exclusive access to a `T` unique storage"]
     #[cfg_attr(
-        feature = "parallel",
+        all(feature = "parallel", docsrs),
+        doc = "* <span style=\"display: table;color: #2f2f2f;background-color: #C4ECFF;border-width: 1px;border-style: solid;border-color: #7BA5DB;padding: 3px;margin-bottom: 5px; font-size: 90%\">This is supported on <strong><code style=\"background-color: #C4ECFF\">feature=\"parallel\"</code></strong> only:</span>"
+    )]
+    #[cfg_attr(
+        all(feature = "parallel", docsrs),
+        doc = "    * [ThreadPool] for a shared access to the `ThreadPool` used by the [World]"
+    )]
+    #[cfg_attr(
+        all(feature = "parallel", not(docsrs)),
         doc = "* [ThreadPool] for a shared access to the `ThreadPool` used by the [World]"
     )]
     #[cfg_attr(
@@ -354,7 +438,17 @@ You can use:
         doc = "* ThreadPool: must activate the *parallel* feature"
     )]
     #[cfg_attr(
-        feature = "non_send",
+        all(feature = "non_send", docsrs),
+        doc = "* <span style=\"display: table;color: #2f2f2f;background-color: #C4ECFF;border-width: 1px;border-style: solid;border-color: #7BA5DB;padding: 3px;margin-bottom: 5px; font-size: 90%\">This is supported on <strong><code style=\"background-color: #C4ECFF\">feature=\"non_send\"</code></strong> only:</span>"
+    )]
+    #[cfg_attr(
+        all(feature = "non_send", docsrs),
+        doc = "    * [NonSend]<&T> for a shared access to a `T` storage where `T` isn't `Send`
+    * [NonSend]<&mut T> for an exclusive access to a `T` storage where `T` isn't `Send`  
+[Unique] and [NonSend] can be used together to access a `!Send` unique storage."
+    )]
+    #[cfg_attr(
+        all(feature = "non_send", not(docsrs)),
         doc = "* [NonSend]<&T> for a shared access to a `T` storage where `T` isn't `Send`
 * [NonSend]<&mut T> for an exclusive access to a `T` storage where `T` isn't `Send`  
 [Unique] and [NonSend] can be used together to access a `!Send` unique storage."
@@ -364,7 +458,17 @@ You can use:
         doc = "* NonSend: must activate the *non_send* feature"
     )]
     #[cfg_attr(
-        feature = "non_sync",
+        all(feature = "non_sync", docsrs),
+        doc = "* <span style=\"display: table;color: #2f2f2f;background-color: #C4ECFF;border-width: 1px;border-style: solid;border-color: #7BA5DB;padding: 3px;margin-bottom: 5px; font-size: 90%\">This is supported on <strong><code style=\"background-color: #C4ECFF\">feature=\"non_sync\"</code></strong> only:</span>"
+    )]
+    #[cfg_attr(
+        all(feature = "non_sync", docsrs),
+        doc = "    * [NonSync]<&T> for a shared access to a `T` storage where `T` isn't `Sync`
+    * [NonSync]<&mut T> for an exclusive access to a `T` storage where `T` isn't `Sync`  
+[Unique] and [NonSync] can be used together to access a `!Sync` unique storage."
+    )]
+    #[cfg_attr(
+        all(feature = "non_sync", not(docsrs)),
         doc = "* [NonSync]<&T> for a shared access to a `T` storage where `T` isn't `Sync`
 * [NonSync]<&mut T> for an exclusive access to a `T` storage where `T` isn't `Sync`  
 [Unique] and [NonSync] can be used together to access a `!Sync` unique storage."
@@ -374,7 +478,17 @@ You can use:
         doc = "* NonSync: must activate the *non_sync* feature"
     )]
     #[cfg_attr(
-        all(feature = "non_send", feature = "non_sync"),
+        all(feature = "non_sync", docsrs),
+        doc = "* <span style=\"display: table;color: #2f2f2f;background-color: #C4ECFF;border-width: 1px;border-style: solid;border-color: #7BA5DB;padding: 3px;margin-bottom: 5px; font-size: 90%\">This is supported on <strong><code style=\"background-color: #C4ECFF\">feature=\"non_send\"</code> and <code style=\"background-color: #C4ECFF\">feature=\"non_sync\"</code></strong> only:</span>"
+    )]
+    #[cfg_attr(
+        all(feature = "non_send", feature = "non_sync", docsrs),
+        doc = "    * [NonSendSync]<&T> for a shared access to a `T` storage where `T` isn't `Send` nor `Sync`
+    * [NonSendSync]<&mut T> for an exclusive access to a `T` storage where `T` isn't `Send` nor `Sync`  
+[Unique] and [NonSendSync] can be used together to access a `!Send + !Sync` unique storage."
+    )]
+    #[cfg_attr(
+        all(feature = "non_send", feature = "non_sync", not(docsrs)),
         doc = "* [NonSendSync]<&T> for a shared access to a `T` storage where `T` isn't `Send` nor `Sync`
 * [NonSendSync]<&mut T> for an exclusive access to a `T` storage where `T` isn't `Send` nor `Sync`  
 [Unique] and [NonSendSync] can be used together to access a `!Send + !Sync` unique storage."
@@ -414,11 +528,19 @@ You can use:
 * `&mut T` for an exclusive access to `T` storage
 * [Entities] for a shared access to the entity storage
 * [EntitiesMut] for an exclusive reference to the entity storage
-* [AllStorages] for an exclusive access to the storage of all components
+* [AllStorages] for an exclusive access to the storage of all components, ⚠️ can't coexist with any other storage borrow
 * [Unique]<&T> for a shared access to a `T` unique storage
 * [Unique]<&mut T> for an exclusive access to a `T` unique storage"]
     #[cfg_attr(
-        feature = "parallel",
+        all(feature = "parallel", docsrs),
+        doc = "* <span style=\"display: table;color: #2f2f2f;background-color: #C4ECFF;border-width: 1px;border-style: solid;border-color: #7BA5DB;padding: 3px;margin-bottom: 5px; font-size: 90%\">This is supported on <strong><code style=\"background-color: #C4ECFF\">feature=\"parallel\"</code></strong> only:</span>"
+    )]
+    #[cfg_attr(
+        all(feature = "parallel", docsrs),
+        doc = "    * [ThreadPool] for a shared access to the `ThreadPool` used by the [World]"
+    )]
+    #[cfg_attr(
+        all(feature = "parallel", not(docsrs)),
         doc = "* [ThreadPool] for a shared access to the `ThreadPool` used by the [World]"
     )]
     #[cfg_attr(
@@ -426,7 +548,17 @@ You can use:
         doc = "* ThreadPool: must activate the *parallel* feature"
     )]
     #[cfg_attr(
-        feature = "non_send",
+        all(feature = "non_send", docsrs),
+        doc = "* <span style=\"display: table;color: #2f2f2f;background-color: #C4ECFF;border-width: 1px;border-style: solid;border-color: #7BA5DB;padding: 3px;margin-bottom: 5px; font-size: 90%\">This is supported on <strong><code style=\"background-color: #C4ECFF\">feature=\"non_send\"</code></strong> only:</span>"
+    )]
+    #[cfg_attr(
+        all(feature = "non_send", docsrs),
+        doc = "    * [NonSend]<&T> for a shared access to a `T` storage where `T` isn't `Send`
+    * [NonSend]<&mut T> for an exclusive access to a `T` storage where `T` isn't `Send`  
+[Unique] and [NonSend] can be used together to access a `!Send` unique storage."
+    )]
+    #[cfg_attr(
+        all(feature = "non_send", not(docsrs)),
         doc = "* [NonSend]<&T> for a shared access to a `T` storage where `T` isn't `Send`
 * [NonSend]<&mut T> for an exclusive access to a `T` storage where `T` isn't `Send`  
 [Unique] and [NonSend] can be used together to access a `!Send` unique storage."
@@ -436,7 +568,17 @@ You can use:
         doc = "* NonSend: must activate the *non_send* feature"
     )]
     #[cfg_attr(
-        feature = "non_sync",
+        all(feature = "non_sync", docsrs),
+        doc = "* <span style=\"display: table;color: #2f2f2f;background-color: #C4ECFF;border-width: 1px;border-style: solid;border-color: #7BA5DB;padding: 3px;margin-bottom: 5px; font-size: 90%\">This is supported on <strong><code style=\"background-color: #C4ECFF\">feature=\"non_sync\"</code></strong> only:</span>"
+    )]
+    #[cfg_attr(
+        all(feature = "non_sync", docsrs),
+        doc = "    * [NonSync]<&T> for a shared access to a `T` storage where `T` isn't `Sync`
+    * [NonSync]<&mut T> for an exclusive access to a `T` storage where `T` isn't `Sync`  
+[Unique] and [NonSync] can be used together to access a `!Sync` unique storage."
+    )]
+    #[cfg_attr(
+        all(feature = "non_sync", not(docsrs)),
         doc = "* [NonSync]<&T> for a shared access to a `T` storage where `T` isn't `Sync`
 * [NonSync]<&mut T> for an exclusive access to a `T` storage where `T` isn't `Sync`  
 [Unique] and [NonSync] can be used together to access a `!Sync` unique storage."
@@ -446,7 +588,17 @@ You can use:
         doc = "* NonSync: must activate the *non_sync* feature"
     )]
     #[cfg_attr(
-        all(feature = "non_send", feature = "non_sync"),
+        all(feature = "non_sync", docsrs),
+        doc = "* <span style=\"display: table;color: #2f2f2f;background-color: #C4ECFF;border-width: 1px;border-style: solid;border-color: #7BA5DB;padding: 3px;margin-bottom: 5px; font-size: 90%\">This is supported on <strong><code style=\"background-color: #C4ECFF\">feature=\"non_send\"</code> and <code style=\"background-color: #C4ECFF\">feature=\"non_sync\"</code></strong> only:</span>"
+    )]
+    #[cfg_attr(
+        all(feature = "non_send", feature = "non_sync", docsrs),
+        doc = "    * [NonSendSync]<&T> for a shared access to a `T` storage where `T` isn't `Send` nor `Sync`
+    * [NonSendSync]<&mut T> for an exclusive access to a `T` storage where `T` isn't `Send` nor `Sync`  
+[Unique] and [NonSendSync] can be used together to access a `!Send + !Sync` unique storage."
+    )]
+    #[cfg_attr(
+        all(feature = "non_send", feature = "non_sync", not(docsrs)),
         doc = "* [NonSendSync]<&T> for a shared access to a `T` storage where `T` isn't `Send` nor `Sync`
 * [NonSendSync]<&mut T> for an exclusive access to a `T` storage where `T` isn't `Send` nor `Sync`  
 [Unique] and [NonSendSync] can be used together to access a `!Send + !Sync` unique storage."

--- a/src/world/mod.rs
+++ b/src/world/mod.rs
@@ -56,6 +56,7 @@ impl World {
     /// Returns a new `World` with custom threads.  
     /// Custom threads can be useful when working with wasm for example.
     #[cfg(feature = "parallel")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "parallel")))]
     pub fn new_with_custom_threads<F: FnMut(rayon::ThreadBuilder) -> Result<(), std::io::Error>>(
         f: F,
     ) -> Self {
@@ -100,6 +101,7 @@ impl World {
     /// [Unique]: struct.Unique.html
     /// [NonSend]: struct.NonSend.html
     #[cfg(feature = "non_send")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "non_send")))]
     pub fn try_add_unique_non_send<T: 'static + Sync>(
         &self,
         component: T,
@@ -117,6 +119,7 @@ impl World {
     /// [Unique]: struct.Unique.html
     /// [NonSend]: struct.NonSend.html
     #[cfg(feature = "non_send")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "non_send")))]
     pub fn add_unique_non_send<T: 'static + Sync>(&self, component: T) {
         self.try_add_unique_non_send::<T>(component).unwrap()
     }
@@ -127,6 +130,7 @@ impl World {
     /// [Unique]: struct.Unique.html
     /// [NonSync]: struct.NonSync.html
     #[cfg(feature = "non_sync")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "non_sync")))]
     pub fn try_add_unique_non_sync<T: 'static + Send>(
         &self,
         component: T,
@@ -144,6 +148,7 @@ impl World {
     /// [Unique]: struct.Unique.html
     /// [NonSync]: struct.NonSync.html
     #[cfg(feature = "non_sync")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "non_sync")))]
     pub fn add_unique_non_sync<T: 'static + Send>(&self, component: T) {
         self.try_add_unique_non_sync::<T>(component).unwrap()
     }
@@ -154,6 +159,7 @@ impl World {
     /// [Unique]: struct.Unique.html
     /// [NonSendSync]: struct.NonSendSync.html
     #[cfg(all(feature = "non_send", feature = "non_sync"))]
+    #[cfg_attr(docsrs, doc(cfg(all(feature = "non_send", feature = "non_sync"))))]
     pub fn try_add_unique_non_send_sync<T: 'static>(
         &self,
         component: T,
@@ -171,6 +177,7 @@ impl World {
     /// [Unique]: struct.Unique.html
     /// [NonSendSync]: struct.NonSendSync.html
     #[cfg(all(feature = "non_send", feature = "non_sync"))]
+    #[cfg_attr(docsrs, doc(cfg(all(feature = "non_send", feature = "non_sync"))))]
     pub fn add_unique_non_send_sync<T: 'static>(&self, component: T) {
         self.try_add_unique_non_send_sync::<T>(component).unwrap()
     }


### PR DESCRIPTION
This PR enables all features when building the documentation for docs.rs and uses a neat trick I found that is being used by tokio to specially mark feature gated items with a small annotation.

![firefox_rSTN7J4QNU](https://user-images.githubusercontent.com/3757771/78423952-69b06400-766a-11ea-819d-a56372f6747e.png)
![firefox_h1xPtnbptu](https://user-images.githubusercontent.com/3757771/78423953-6a48fa80-766a-11ea-936f-074c9ab24905.png)
![firefox_oFyjY024OW](https://user-images.githubusercontent.com/3757771/78423972-906e9a80-766a-11ea-8690-65e248d0fd18.png)

To see this locally one has to set the `RUSTDOCFLAGS=--cfg docsrs` variable.