### PR TITLE
Implement StorageBorrow for (), same way as SystemData is implemented for it

### DIFF
--- a/src/run/storage_borrow.rs
+++ b/src/run/storage_borrow.rs
@@ -15,6 +15,14 @@ pub trait StorageBorrow<'a> {
     fn try_borrow(all_storages: &'a AllStorages) -> Result<Self::View, error::GetStorage>;
 }
 
+impl<'a> StorageBorrow<'a> for () {
+    type View = ();
+
+    fn try_borrow(_: &'a AllStorages) -> Result<Self::View, error::GetStorage> {
+        Ok(())
+    }
+}
+
 impl<'a> StorageBorrow<'a> for Entities {
     type View = EntitiesView<'a>;
 


### PR DESCRIPTION
`SystemData` is implemented for it here https://github.com/leudz/shipyard/blob/d957c19ba9c2f0bf326258d07bae4cff2c54fe30/src/run/system_data.rs#L39-L54 but `StorageBorrow` is not.