### PR TITLE
Add "unwrap_get" default feature to gate `get` fn

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,8 @@ parking_lot = { version = "^0.10" }
 hashbrown = "^0.7"
 
 [features]
-default = ["parallel"]
+default = ["parallel", "unwrap_get"]
+unwrap_get = []
 parallel = ["rayon", "num_cpus", "std"]
 non_send = ["std"]
 non_sync = ["std"]

--- a/src/get.rs
+++ b/src/get.rs
@@ -7,6 +7,7 @@ use core::any::type_name;
 /// Retrives components based on their type and entity id.
 pub trait Get {
     type Out;
+
     /// Retrieve components of `entity`.
     ///
     /// Multiple components can be queried at the same time using a tuple.
@@ -25,6 +26,8 @@ pub trait Get {
     /// );
     /// ```
     fn try_get(self, entity: EntityId) -> Result<Self::Out, error::MissingComponent>;
+
+    #[cfg(feature = "unwrap_get")]
     /// Retrieve components of `entity`.  
     /// Unwraps errors.
     ///
@@ -54,6 +57,7 @@ impl<'a: 'b, 'b, T: 'static> Get for &'b Window<'a, T> {
             name: type_name::<T>(),
         })
     }
+    #[cfg(feature = "unwrap_get")]
     fn get(self, entity: EntityId) -> Self::Out {
         self.try_get(entity).unwrap()
     }
@@ -67,6 +71,7 @@ impl<'a: 'b, 'b, T: 'static> Get for &'b WindowMut<'a, T> {
             name: type_name::<T>(),
         })
     }
+    #[cfg(feature = "unwrap_get")]
     fn get(self, entity: EntityId) -> Self::Out {
         self.try_get(entity).unwrap()
     }
@@ -80,6 +85,7 @@ impl<'a: 'b, 'b, T: 'static> Get for &'b mut WindowMut<'a, T> {
             name: type_name::<T>(),
         })
     }
+    #[cfg(feature = "unwrap_get")]
     fn get(self, entity: EntityId) -> Self::Out {
         self.try_get(entity).unwrap()
     }
@@ -93,6 +99,7 @@ impl<'a: 'b, 'b, T: 'static> Get for &'b View<'a, T> {
             name: type_name::<T>(),
         })
     }
+    #[cfg(feature = "unwrap_get")]
     fn get(self, entity: EntityId) -> Self::Out {
         self.try_get(entity).unwrap()
     }
@@ -106,6 +113,7 @@ impl<'a: 'b, 'b, T: 'static> Get for &'b ViewMut<'a, T> {
             name: type_name::<T>(),
         })
     }
+    #[cfg(feature = "unwrap_get")]
     fn get(self, entity: EntityId) -> Self::Out {
         self.try_get(entity).unwrap()
     }
@@ -119,6 +127,7 @@ impl<'a: 'b, 'b, T: 'static> Get for &'b mut ViewMut<'a, T> {
             name: type_name::<T>(),
         })
     }
+    #[cfg(feature = "unwrap_get")]
     fn get(self, entity: EntityId) -> Self::Out {
         self.try_get(entity).unwrap()
     }
@@ -131,6 +140,7 @@ macro_rules! impl_get_component {
             fn try_get(self, entity: EntityId) -> Result<Self::Out, error::MissingComponent> {
                 Ok(($(self.$index.try_get(entity)?,)+))
             }
+            #[cfg(feature = "unwrap_get")]
             fn get(self, entity: EntityId) -> Self::Out {
                 self.try_get(entity).unwrap()
             }

--- a/tests/add_component.rs
+++ b/tests/add_component.rs
@@ -9,7 +9,7 @@ fn no_pack() {
     let entity1 = entities.add_entity((), ());
     entities.add_component((&mut usizes, &mut u32s), (0, 1), entity1);
     entities.add_component((&mut u32s, &mut usizes), (3, 2), entity1);
-    assert_eq!((&usizes, &u32s).get(entity1), (&2, &3));
+    assert_eq!((&usizes, &u32s).try_get(entity1).unwrap(), (&2, &3));
 }
 
 #[test]


### PR DESCRIPTION
First part of #80 for review.

Please share feedback on the approach. I was thinking about separating the `unwrap_` features based on which parts of `shipyard` you want to have unwrap versions. For me this is optimal since I really only care about not including `get`.

All other panics that can be induced by borrowing or other are fine for my codebase now, so I don't want to have one feature for all unwrapped versions of everything.