### PR TITLE
Add WorkloadBuilder::apply().

### DIFF
--- a/src/world/scheduler/builder.rs
+++ b/src/world/scheduler/builder.rs
@@ -143,33 +143,43 @@ impl<'a> WorkloadBuilder<'a> {
     ) -> WorkloadBuilder<'a> {
         self.try_with_system(system).unwrap()
     }
-    /// Calls the given function on `self` and returns the result.
+    /// Calls the given function on the builder.
     ///
     /// Can be useful to chain calls to functions that modify a `WorkloadBuilder`.
     ///
     /// ### Example:
     /// ```
-    /// use shipyard::{system, WorkloadBuilder, World};
+    /// use shipyard::World;
     ///
-    /// fn my_system() {}
+    /// mod mod1 {
+    ///     use shipyard::{system, WorkloadBuilder};
     ///
-    /// fn register_systems<'a>(workload: WorkloadBuilder<'a>) -> WorkloadBuilder<'a> {
-    ///     workload.with_system(system!(my_system))
+    ///     fn private_system() {}
+    ///
+    ///     pub fn register_systems(workload: WorkloadBuilder) -> WorkloadBuilder {
+    ///         workload.with_system(system!(private_system))
+    ///     }
     /// }
     ///
-    /// fn register_more_systems<'a>(workload: WorkloadBuilder<'a>) -> WorkloadBuilder<'a> {
-    ///     workload.with_system(system!(|| {}))
+    /// mod mod2 {
+    ///     use shipyard::{system, WorkloadBuilder};
+    ///
+    ///     fn private_system() {}
+    ///
+    ///     pub fn register_systems(workload: WorkloadBuilder) -> WorkloadBuilder {
+    ///         workload.with_system(system!(private_system))
+    ///     }
     /// }
     ///
     /// World::new()
     ///     .add_workload("My workload")
-    ///     .apply(register_systems)
-    ///     .apply(register_more_systems)
+    ///     .apply(mod1::register_systems)
+    ///     .apply(mod2::register_systems)
     ///     .build();
     /// ```
     pub fn apply<F>(self, f: F) -> Self
     where
-        F: Fn(Self) -> Self,
+        F: FnOnce(Self) -> Self,
     {
         f(self)
     }

--- a/src/world/scheduler/builder.rs
+++ b/src/world/scheduler/builder.rs
@@ -143,6 +143,36 @@ impl<'a> WorkloadBuilder<'a> {
     ) -> WorkloadBuilder<'a> {
         self.try_with_system(system).unwrap()
     }
+    /// Calls the given function on `self` and returns the result.
+    ///
+    /// Can be useful to chain calls to functions that modify a `WorkloadBuilder`.
+    ///
+    /// ### Example:
+    /// ```
+    /// use shipyard::{system, WorkloadBuilder, World};
+    ///
+    /// fn my_system() {}
+    ///
+    /// fn register_systems<'a>(workload: WorkloadBuilder<'a>) -> WorkloadBuilder<'a> {
+    ///     workload.with_system(system!(my_system))
+    /// }
+    ///
+    /// fn register_more_systems<'a>(workload: WorkloadBuilder<'a>) -> WorkloadBuilder<'a> {
+    ///     workload.with_system(system!(|| {}))
+    /// }
+    ///
+    /// World::new()
+    ///     .add_workload("My workload")
+    ///     .apply(register_systems)
+    ///     .apply(register_more_systems)
+    ///     .build();
+    /// ```
+    pub fn apply<F>(self, f: F) -> Self
+    where
+        F: Fn(Self) -> Self,
+    {
+        f(self)
+    }
     /// Finishes the workload creation and store it in the `World`.
     pub fn build(mut self) {
         if self.systems.len() == 1 {


### PR DESCRIPTION
Hi, thanks for the great crate!

This adds a `.apply()` method that calls a given function on a workload builder for syntactic convenience. The use case is that instead of the typical usage:
```rust
world
    .add_workload("name")
    .with_system(system1)
    .with_system(system2)
    .build();
```
I'm registering sets of systems in different modules, and building a workload by composing those calls:
```rust
mod mod1 {
    fn register_systems<'a>(workload: WorkloadBuilder<'a>) -> WorkloadBuilder<'a> {
        workload
            .with_system(system1a)
            .with_system(system1b)
    }
}

mod mod2 { /* ... */ }

let workload = world.add_workload("name");
let workload = mod1::register_systems(workload);
let workload = mod2::register_systems(workload);
workload.build();
```
Which is a little verbose, `.apply()` cleans it up a little:
```rust
world
    .add_workload()
    .apply(mod1::register_systems)
    .apply(mod2::register_systems)
    .build();
```