### PR TITLE
WIP World::take_unique()

### DIFF
--- a/src/atomic_refcell.rs
+++ b/src/atomic_refcell.rs
@@ -91,6 +91,15 @@ impl<T: ?Sized> AtomicRefCell<T> {
     }
 }
 
+impl AtomicRefCell<dyn crate::unknown_storage::UnknownStorage> {
+    /// # Safety
+    ///
+    /// `T` has to be a unique storage of the right type.
+    pub unsafe fn into_unique<T: 'static>(mut this: Box<Self>) -> T {
+        todo!()
+    }
+}
+
 /// `BorrowState` keeps track of which borrow is currently active.
 // If `HIGH_BIT` is set, it is a unique borrow, in all other cases it is a shared borrowed
 #[doc(hidden)]

--- a/src/storage/all/mod.rs
+++ b/src/storage/all/mod.rs
@@ -345,7 +345,7 @@ impl AllStorages {
             Err(error::GetStorage::MissingUnique(core::any::type_name::<T>()))
         }
     }
-    pub(crate) fn take_unique<T: 'static>(&self) -> Result<T, error::GetStorage> {
+    pub(crate) fn remove_unique<T: 'static>(&self) -> Result<T, error::GetStorage> {
         let type_id = TypeId::of::<T>();
         self.lock.lock_exclusive();
         // SAFE we locked

--- a/src/storage/all/mod.rs
+++ b/src/storage/all/mod.rs
@@ -352,9 +352,9 @@ impl AllStorages {
         let storages = unsafe { &mut *self.storages.get() };
         if let Entry::Occupied(entry) = storages.entry(type_id) {
             // `.err()` to avoid borrowing `entry` in the `Ok` case
-            if let Some(err) = entry.get().unique_mut::<T>().err() {
+            if let Some(get_storage) = entry.get().unique_mut::<T>().err() {
                 self.lock.unlock_exclusive();
-                Err(err)
+                Err(get_storage)
             } else {
                 // We were able to lock the storage, we've still got exclusive access even though
                 // we released that lock as we're still holding the `AllStorages` lock.

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -202,6 +202,9 @@ impl Storage {
             },
         )
     }
+    pub(crate) fn take_unique<T: 'static>(self) -> Result<T, error::GetStorage> {
+        todo!()
+    }
     /// Mutably borrows the container and delete `index`.
     pub(crate) fn delete(
         &mut self,

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -203,7 +203,12 @@ impl Storage {
         )
     }
     pub(crate) fn take_unique<T: 'static>(self) -> Result<T, error::GetStorage> {
-        todo!()
+        // We already have exclusive access, but need to verify that this is actually a
+        // `Unique<T>`.
+        self.unique_mut::<T>()?;
+        // SAFE the cast to `T` succeeded.
+        let storage = unsafe { AtomicRefCell::into_unique::<Unique<T>>(self.0) };
+        Ok(storage.into_inner())
     }
     /// Mutably borrows the container and delete `index`.
     pub(crate) fn delete(

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -202,14 +202,6 @@ impl Storage {
             },
         )
     }
-    pub(crate) fn take_unique<T: 'static>(self) -> Result<T, error::GetStorage> {
-        // We already have exclusive access, but need to verify that this is actually a
-        // `Unique<T>`.
-        self.unique_mut::<T>()?;
-        // SAFE the cast to `T` succeeded.
-        let storage = unsafe { AtomicRefCell::into_unique::<Unique<T>>(self.0) };
-        Ok(storage.into_inner())
-    }
     /// Mutably borrows the container and delete `index`.
     pub(crate) fn delete(
         &mut self,

--- a/src/storage/unique.rs
+++ b/src/storage/unique.rs
@@ -5,6 +5,12 @@ use core::any::{Any, TypeId};
 
 pub(crate) struct Unique<T>(pub(crate) T);
 
+impl<T> Unique<T> {
+    pub(crate) fn into_inner(self) -> T {
+        self.0
+    }
+}
+
 impl<T: 'static> UnknownStorage for Unique<T> {
     fn delete(&mut self, _: EntityId, _: &mut Vec<TypeId>) {}
     fn clear(&mut self) {}

--- a/src/storage/unique.rs
+++ b/src/storage/unique.rs
@@ -5,12 +5,6 @@ use core::any::{Any, TypeId};
 
 pub(crate) struct Unique<T>(pub(crate) T);
 
-impl<T> Unique<T> {
-    pub(crate) fn into_inner(self) -> T {
-        self.0
-    }
-}
-
 impl<T: 'static> UnknownStorage for Unique<T> {
     fn delete(&mut self, _: EntityId, _: &mut Vec<TypeId>) {}
     fn clear(&mut self) {}

--- a/src/storage/unique.rs
+++ b/src/storage/unique.rs
@@ -3,7 +3,7 @@ use crate::unknown_storage::UnknownStorage;
 use alloc::vec::Vec;
 use core::any::{Any, TypeId};
 
-pub(crate) struct Unique<T>(pub(crate) T);
+pub(super) struct Unique<T>(pub(crate) T);
 
 impl<T: 'static> UnknownStorage for Unique<T> {
     fn delete(&mut self, _: EntityId, _: &mut Vec<TypeId>) {}

--- a/src/world/mod.rs
+++ b/src/world/mod.rs
@@ -200,8 +200,8 @@ impl World {
     pub fn try_take_unique<T: 'static>(&self) -> Result<T, error::GetStorage> {
         self.all_storages
             .try_borrow_mut()
-            .map_err(|err| {
-                error::GetStorage::StorageBorrow((core::any::type_name::<T>(), err))
+            .map_err(|borrow| {
+                error::GetStorage::AllStoragesBorrow(borrow)
             })?
             .take_unique()
     }

--- a/src/world/mod.rs
+++ b/src/world/mod.rs
@@ -196,6 +196,20 @@ impl World {
     pub fn add_unique_non_send_sync<T: 'static>(&self, component: T) {
         self.try_add_unique_non_send_sync::<T>(component).unwrap()
     }
+    /// Fetches a unique storage, removing it from the world.
+    pub fn try_take_unique<T: 'static>(&self) -> Result<T, error::GetStorage> {
+        self.all_storages
+            .try_borrow_mut()
+            .map_err(|err| {
+                error::GetStorage::StorageBorrow((core::any::type_name::<T>(), err))
+            })?
+            .take_unique()
+    }
+    /// Fetches a unique storage, removing it from the world.
+    /// Unwraps errors.
+    pub fn take_unique<T: 'static>(&self) -> T {
+        self.try_take_unique().unwrap()
+    }
     #[doc = "Borrows the requested storage(s), if it doesn't exist it'll get created.  
 You can use a tuple to get multiple storages at once.
 

--- a/src/world/mod.rs
+++ b/src/world/mod.rs
@@ -199,7 +199,7 @@ impl World {
     /// Removes a unique storage.
     pub fn try_remove_unique<T: 'static>(&self) -> Result<T, error::GetStorage> {
         self.all_storages
-            .try_borrow_mut()
+            .try_borrow()
             .map_err(|borrow| error::GetStorage::AllStoragesBorrow(borrow))?
             .remove_unique()
     }

--- a/src/world/mod.rs
+++ b/src/world/mod.rs
@@ -201,10 +201,12 @@ impl World {
         self.all_storages
             .try_borrow()
             .map_err(|_| error::UniqueRemove::AllStorages)?
-            .remove_unique()
+            .remove_unique::<T>()
     }
     /// Removes a unique storage.
     /// Unwraps errors.
+    #[cfg(feature = "panic")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "panic")))]
     pub fn remove_unique<T: 'static>(&self) -> T {
         self.try_remove_unique().unwrap()
     }

--- a/src/world/mod.rs
+++ b/src/world/mod.rs
@@ -196,17 +196,17 @@ impl World {
     pub fn add_unique_non_send_sync<T: 'static>(&self, component: T) {
         self.try_add_unique_non_send_sync::<T>(component).unwrap()
     }
-    /// Fetches a unique storage, removing it from the world.
-    pub fn try_take_unique<T: 'static>(&self) -> Result<T, error::GetStorage> {
+    /// Removes a unique storage.
+    pub fn try_remove_unique<T: 'static>(&self) -> Result<T, error::GetStorage> {
         self.all_storages
             .try_borrow_mut()
             .map_err(|borrow| error::GetStorage::AllStoragesBorrow(borrow))?
-            .take_unique()
+            .remove_unique()
     }
-    /// Fetches a unique storage, removing it from the world.
+    /// Removes a unique storage.
     /// Unwraps errors.
-    pub fn take_unique<T: 'static>(&self) -> T {
-        self.try_take_unique().unwrap()
+    pub fn remove_unique<T: 'static>(&self) -> T {
+        self.try_remove_unique().unwrap()
     }
     #[doc = "Borrows the requested storage(s), if it doesn't exist it'll get created.  
 You can use a tuple to get multiple storages at once.

--- a/src/world/mod.rs
+++ b/src/world/mod.rs
@@ -197,10 +197,10 @@ impl World {
         self.try_add_unique_non_send_sync::<T>(component).unwrap()
     }
     /// Removes a unique storage.
-    pub fn try_remove_unique<T: 'static>(&self) -> Result<T, error::GetStorage> {
+    pub fn try_remove_unique<T: 'static>(&self) -> Result<T, error::UniqueRemove> {
         self.all_storages
             .try_borrow()
-            .map_err(|borrow| error::GetStorage::AllStoragesBorrow(borrow))?
+            .map_err(|_| error::UniqueRemove::AllStorages)?
             .remove_unique()
     }
     /// Removes a unique storage.

--- a/src/world/mod.rs
+++ b/src/world/mod.rs
@@ -200,9 +200,7 @@ impl World {
     pub fn try_take_unique<T: 'static>(&self) -> Result<T, error::GetStorage> {
         self.all_storages
             .try_borrow_mut()
-            .map_err(|borrow| {
-                error::GetStorage::AllStoragesBorrow(borrow)
-            })?
+            .map_err(|borrow| error::GetStorage::AllStoragesBorrow(borrow))?
             .take_unique()
     }
     /// Fetches a unique storage, removing it from the world.


### PR DESCRIPTION
I'm trying to add support for moving a unique component out of the world:
```rust
struct MyComponent;

impl MyComponent {
    fn cleanup(self) {}
}

world.add_unique(MyComponent);
world.take_unique::<MyComponent>().cleanup();
assert!(world.try_borrow::<UniqueView<MyComponent>>().is_err());
```
and having trouble coming up with a clean `Storage` interface since we can't consume the storage while holding a `RefMut`. One naive idea would be adding `Storage::try_lock(&self) -> bool` and `Storage::take<T>(self) -> T` and just
```rust
if storage.try_lock() {
    // we got an exclusive lock
    Ok(storage.take())
}
```
but that interface doesn't enforce that `try_lock()` was actually called. Is there some pattern that could be used here, or some totally different way of going about it?

Thanks!