### PR TITLE
Borrow `AllStorages` immutably in `World::try_add_unique*()`

### DIFF
--- a/src/world/mod.rs
+++ b/src/world/mod.rs
@@ -96,7 +96,7 @@ impl World {
         component: T,
     ) -> Result<(), error::Borrow> {
         self.all_storages
-            .try_borrow_mut()?
+            .try_borrow()?
             .register_unique(component);
         Ok(())
     }
@@ -114,7 +114,7 @@ impl World {
         component: T,
     ) -> Result<(), error::Borrow> {
         self.all_storages
-            .try_borrow_mut()?
+            .try_borrow()?
             .register_unique_non_send(component);
         Ok(())
     }
@@ -145,7 +145,7 @@ impl World {
         component: T,
     ) -> Result<(), error::Borrow> {
         self.all_storages
-            .try_borrow_mut()?
+            .try_borrow()?
             .register_unique_non_sync(component);
         Ok(())
     }
@@ -176,7 +176,7 @@ impl World {
         component: T,
     ) -> Result<(), error::Borrow> {
         self.all_storages
-            .try_borrow_mut()?
+            .try_borrow()?
             .register_unique_non_send_sync(component);
         Ok(())
     }


### PR DESCRIPTION
Pretty sure this is right, same as your fix [here](https://github.com/leudz/shipyard/commit/45546ad62bdfc584b9a04baf2f7b768477b9ec1c). Allows the following, which fails on master:
```rust
use shipyard::*;

struct S1;
struct S2;

let world = World::new();
world.add_unique(S1);
let _s = world.borrow::<UniqueView<'_, S1>>();
world.add_unique(S2);  // => "Cannot mutably borrow while already borrowed."
```