### PR TITLE
Scripting Support

### DIFF
--- a/examples/custom_component.rs
+++ b/examples/custom_component.rs
@@ -1,0 +1,70 @@
+use shipyard::*;
+use std::convert::TryInto;
+
+use std::collections::HashMap;
+
+struct Nothing;
+
+struct ScriptSystem {
+    name: String,
+}
+
+fn main() {
+    // This stores our components by name
+    let mut components: HashMap<String, CustomComponent> = HashMap::new();
+
+    // Insert our custom components
+    components.insert(
+        "position".into(),
+        CustomComponent {
+            size: 32.try_into().unwrap(),
+            id: 0,
+        },
+    );
+
+    components.insert(
+        "velocity".into(),
+        CustomComponent {
+            size: 16.try_into().unwrap(),
+            id: 1,
+        },
+    );
+
+    // Create a custom system
+    let insert_pos_vel_sys = DynamicSystem {
+        data: (),
+        system_fn: |_, borrows| {},
+        borrow_intents: vec![
+            CustomComponentBorrowIntent {
+                component: components.get("velocity").unwrap().clone(),
+                mutation: Mutation::Shared,
+            },
+            CustomComponentBorrowIntent {
+                component: components.get("position").unwrap().clone(),
+                mutation: Mutation::Unique,
+            },
+        ],
+    };
+
+    let pos_vel_sys = DynamicSystem {
+        data: (),
+        system_fn: |_, borrows| {
+            let velocities = borrows.get(0).unwrap();
+            let positions = borrows.get(0).unwrap();
+        },
+        borrow_intents: vec![
+            CustomComponentBorrowIntent {
+                component: components.get("velocity").unwrap().clone(),
+                mutation: Mutation::Shared,
+            },
+            CustomComponentBorrowIntent {
+                component: components.get("position").unwrap().clone(),
+                mutation: Mutation::Unique,
+            },
+        ],
+    };
+
+    let world = World::new();
+    world.run(insert_pos_vel_sys);
+    world.run(pos_vel_sys);
+}

--- a/examples/custom_component.rs
+++ b/examples/custom_component.rs
@@ -49,8 +49,11 @@ fn main() {
     let pos_vel_sys = DynamicSystem {
         data: (),
         system_fn: |_, borrows| {
-            let velocities = borrows.get(0).unwrap();
-            let positions = borrows.get(0).unwrap();
+            // Need to do something like this, but I cant!
+            let velocities = borrows.get(0).unwrap().downcast::<DynamicView<[u8; 16]>>().unwrap();
+            let positions = borrows.get(1).unwrap().downcast::<DynamicViewMut<[u8; 32]>>().unwrap();
+
+            dbg!(velocities, positions);
         },
         borrow_intents: vec![
             CustomComponentBorrowIntent {

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -1,0 +1,45 @@
+use shipyard::*;
+
+#[derive(Debug)]
+struct Position {
+    x: f32,
+    y: f32,
+}
+
+struct Velocity {
+    x: f32,
+    y: f32,
+}
+
+fn position_printer(positions: View<Position>) {
+    for pos in positions.iter() {
+        println!("position: {:?}", pos);
+    }
+}
+
+fn velocity_handler(mut positions: ViewMut<Position>, velocities: View<Velocity>) {
+    for (mut pos, vel) in (&mut positions, &velocities).iter() {
+        pos.x += vel.x;
+        pos.y += vel.y;
+    }
+}
+
+fn main() {
+    let world = World::new();
+
+    world.run(
+        |mut entities: EntitiesViewMut,
+         mut positions: ViewMut<Position>,
+         mut velocities: ViewMut<Velocity>| {
+            entities.add_entity(
+                (&mut positions, &mut velocities),
+                (Position { x: 10., y: 10. }, Velocity { x: 10., y: 10. }),
+            );
+        },
+    );
+
+    loop {
+        world.run(velocity_handler);
+        world.run(position_printer);
+    }
+}

--- a/src/delete.rs
+++ b/src/delete.rs
@@ -55,9 +55,9 @@ macro_rules! impl_delete {
             fn try_delete(self, entity: EntityId) -> Result<(), error::Remove> {
                 // non packed storages should not pay the price of pack
                 if $(core::mem::discriminant(&self.$index.pack_info.pack) != core::mem::discriminant(&Pack::NoPack) || !self.$index.pack_info.observer_types.is_empty())||+ {
-                    let mut types = [$(TypeId::of::<$type>()),+];
+                    let mut types = [$(TypeId::of::<$type>().into()),+];
                     types.sort_unstable();
-                    let mut add_types = [$(TypeId::of::<$add_type>()),*];
+                    let mut add_types = [$(TypeId::of::<$add_type>().into()),*];
                     add_types.sort_unstable();
 
                     let mut should_unpack = Vec::with_capacity(types.len() + add_types.len());
@@ -81,7 +81,7 @@ macro_rules! impl_delete {
                     )+
 
                     $(
-                        if should_unpack.contains(&TypeId::of::<$add_type>()) {
+                        if should_unpack.contains(&TypeId::of::<$add_type>().into()) {
                             self.$add_index.unpack(entity);
                         }
                     )*

--- a/src/iter/into_abstract.rs
+++ b/src/iter/into_abstract.rs
@@ -1,6 +1,7 @@
 use super::abstract_mut::AbstractMut;
 use crate::not::Not;
 use crate::sparse_set::{Pack, PackInfo, RawWindowMut, Window, WindowMut};
+use crate::storage::StorageId;
 use crate::view::{View, ViewMut};
 use core::any::TypeId;
 
@@ -14,7 +15,7 @@ pub trait IntoAbstract {
     fn into_abstract(self) -> Self::AbsView;
     fn len(&self) -> Option<usize>;
     fn pack_info(&self) -> &PackInfo<Self::PackType>;
-    fn type_id(&self) -> TypeId;
+    fn storage_id(&self) -> StorageId;
     fn modified(&self) -> usize;
     fn offset(&self) -> usize;
 }
@@ -31,8 +32,8 @@ impl<'a, T: 'static> IntoAbstract for &'a View<'_, T> {
     fn pack_info(&self) -> &PackInfo<Self::PackType> {
         <Window<'_, T>>::pack_info(self)
     }
-    fn type_id(&self) -> TypeId {
-        TypeId::of::<T>()
+    fn storage_id(&self) -> StorageId {
+        TypeId::of::<T>().into()
     }
     fn modified(&self) -> usize {
         core::usize::MAX
@@ -54,8 +55,8 @@ impl<'a, T: 'static> IntoAbstract for Window<'a, T> {
     fn pack_info(&self) -> &PackInfo<Self::PackType> {
         self.pack_info()
     }
-    fn type_id(&self) -> TypeId {
-        TypeId::of::<T>()
+    fn storage_id(&self) -> StorageId {
+        TypeId::of::<T>().into()
     }
     fn modified(&self) -> usize {
         core::usize::MAX
@@ -77,8 +78,8 @@ impl<'a, T: 'static> IntoAbstract for &'a Window<'a, T> {
     fn pack_info(&self) -> &PackInfo<Self::PackType> {
         <Window<'_, T>>::pack_info(self)
     }
-    fn type_id(&self) -> TypeId {
-        TypeId::of::<T>()
+    fn storage_id(&self) -> StorageId {
+        TypeId::of::<T>().into()
     }
     fn modified(&self) -> usize {
         core::usize::MAX
@@ -100,8 +101,8 @@ impl<'a: 'b, 'b, T: 'static> IntoAbstract for &'b ViewMut<'a, T> {
     fn pack_info(&self) -> &PackInfo<Self::PackType> {
         &self.pack_info
     }
-    fn type_id(&self) -> TypeId {
-        TypeId::of::<T>()
+    fn storage_id(&self) -> StorageId {
+        TypeId::of::<T>().into()
     }
     fn modified(&self) -> usize {
         core::usize::MAX
@@ -123,8 +124,8 @@ impl<'a: 'b, 'b, T: 'static> IntoAbstract for &'b mut ViewMut<'a, T> {
     fn pack_info(&self) -> &PackInfo<Self::PackType> {
         &self.pack_info
     }
-    fn type_id(&self) -> TypeId {
-        TypeId::of::<T>()
+    fn storage_id(&self) -> StorageId {
+        TypeId::of::<T>().into()
     }
     fn modified(&self) -> usize {
         match &self.pack_info.pack {
@@ -149,8 +150,8 @@ impl<'a, T: 'static> IntoAbstract for WindowMut<'a, T> {
     fn pack_info(&self) -> &PackInfo<Self::PackType> {
         self.pack_info()
     }
-    fn type_id(&self) -> TypeId {
-        TypeId::of::<T>()
+    fn storage_id(&self) -> StorageId {
+        TypeId::of::<T>().into()
     }
     fn modified(&self) -> usize {
         match &self.pack_info().pack {
@@ -175,8 +176,8 @@ impl<'a: 'b, 'b, T: 'static> IntoAbstract for &'b WindowMut<'a, T> {
     fn pack_info(&self) -> &PackInfo<Self::PackType> {
         <WindowMut<'_, T>>::pack_info(self)
     }
-    fn type_id(&self) -> TypeId {
-        TypeId::of::<T>()
+    fn storage_id(&self) -> StorageId {
+        TypeId::of::<T>().into()
     }
     fn modified(&self) -> usize {
         core::usize::MAX
@@ -198,8 +199,8 @@ impl<'a: 'b, 'b, T: 'static> IntoAbstract for &'b mut WindowMut<'a, T> {
     fn pack_info(&self) -> &PackInfo<Self::PackType> {
         <WindowMut<'_, T>>::pack_info(self)
     }
-    fn type_id(&self) -> TypeId {
-        TypeId::of::<T>()
+    fn storage_id(&self) -> StorageId {
+        TypeId::of::<T>().into()
     }
     fn modified(&self) -> usize {
         match &self.pack_info().pack {
@@ -224,8 +225,8 @@ impl<'a: 'b, 'b, T: 'static> IntoAbstract for Not<&'b View<'a, T>> {
     fn pack_info(&self) -> &PackInfo<Self::PackType> {
         self.0.pack_info()
     }
-    fn type_id(&self) -> TypeId {
-        TypeId::of::<T>()
+    fn storage_id(&self) -> StorageId {
+        TypeId::of::<T>().into()
     }
     fn modified(&self) -> usize {
         core::usize::MAX
@@ -247,8 +248,8 @@ impl<'a: 'b, 'b, T: 'static> IntoAbstract for Not<&'b ViewMut<'a, T>> {
     fn pack_info(&self) -> &PackInfo<Self::PackType> {
         &self.0.pack_info
     }
-    fn type_id(&self) -> TypeId {
-        TypeId::of::<T>()
+    fn storage_id(&self) -> StorageId {
+        TypeId::of::<T>().into()
     }
     fn modified(&self) -> usize {
         core::usize::MAX
@@ -270,8 +271,8 @@ impl<'a: 'b, 'b, T: 'static> IntoAbstract for Not<&'b mut ViewMut<'a, T>> {
     fn pack_info(&self) -> &PackInfo<Self::PackType> {
         &self.0.pack_info
     }
-    fn type_id(&self) -> TypeId {
-        TypeId::of::<T>()
+    fn storage_id(&self) -> StorageId {
+        TypeId::of::<T>().into()
     }
     fn modified(&self) -> usize {
         core::usize::MAX

--- a/src/iter/into_iter/multiple.rs
+++ b/src/iter/into_iter/multiple.rs
@@ -26,8 +26,8 @@ macro_rules! impl_iterators {
                     None,
                 }
 
-                let mut type_ids = [$(self.$index.type_id()),+];
-                type_ids.sort_unstable();
+                let mut storage_ids = [$(self.$index.storage_id().into()),+];
+                storage_ids.sort_unstable();
                 let mut smallest_index = core::usize::MAX;
                 let mut smallest = core::usize::MAX;
                 let mut i = 0;
@@ -38,8 +38,8 @@ macro_rules! impl_iterators {
                     if pack_iter == PackIter::None || pack_iter == PackIter::Update {
                         match (&self.$index.pack_info().pack, is_offseted) {
                             (Pack::Tight(pack), false) => {
-                                if let Ok(types) = pack.is_packable(&type_ids) {
-                                    if types.len() == type_ids.len() {
+                                if let Ok(types) = pack.is_packable(&storage_ids) {
+                                    if types.len() == storage_ids.len() {
                                         pack_iter = PackIter::Tight;
                                         smallest = pack.len;
                                     } else if pack.len < smallest {
@@ -54,8 +54,8 @@ macro_rules! impl_iterators {
                                 }
                             }
                             (Pack::Loose(pack), false) => {
-                                if pack.is_packable(&type_ids).is_ok() {
-                                    if pack.tight_types.len() + pack.loose_types.len() == type_ids.len() {
+                                if pack.is_packable(&storage_ids).is_ok() {
+                                    if pack.tight_types.len() + pack.loose_types.len() == storage_ids.len() {
                                         pack_iter = PackIter::Loose;
                                         smallest = pack.len;
                                         smallest_index = i;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -170,7 +170,7 @@ pub use crate::borrow::NonSendSync;
 pub use crate::borrow::NonSync;
 #[doc(hidden)]
 pub use crate::borrow::{AllStoragesBorrow, Borrow};
-pub use borrow::FakeBorrow;
+pub use borrow::{FakeBorrow, Mutation};
 pub use delete::Delete;
 pub use get::Get;
 pub use iter::{
@@ -186,7 +186,10 @@ pub use sparse_set::{
 };
 pub use storage::{AllStorages, DeleteAny, Entities, EntityId};
 #[doc(hidden)]
-pub use system::{AllSystem, Nothing, System};
+pub use system::{
+    AllSystem, CustomComponent, CustomComponentBorrowIntent, CustomComponentSize,
+    CustomComponentSizeError, DynamicSystem, Nothing, System,
+};
 #[cfg(feature = "parallel")]
 pub use view::ThreadPoolView;
 pub use view::{

--- a/src/pack/loose.rs
+++ b/src/pack/loose.rs
@@ -66,11 +66,11 @@ macro_rules! impl_loose_pack {
                 )+
 
                 // we gather and sort all TypeId
-                let mut tight_types: Box<[_]> = Box::new([$(TypeId::of::<$tight>()),+]);
+                let mut tight_types: Box<[_]> = Box::new([$(TypeId::of::<$tight>().into()),+]);
                 tight_types.sort_unstable();
                 let tight_types: Arc<[_]> = tight_types.into();
 
-                let mut loose_types: Box<[_]> = Box::new([$(TypeId::of::<$loose>()),+]);
+                let mut loose_types: Box<[_]> = Box::new([$(TypeId::of::<$loose>().into()),+]);
                 loose_types.sort_unstable();
                 let loose_types: Arc<[_]> = loose_types.into();
 

--- a/src/pack/tight.rs
+++ b/src/pack/tight.rs
@@ -47,7 +47,7 @@ macro_rules! impl_tight_pack {
         #[allow(clippy::useless_let_if_seq)]
         impl<$($type: 'static),+> TightPack for ($(&mut ViewMut<'_, $type>,)+) {
             fn try_tight_pack(self) -> Result<(), error::Pack> {
-                let mut type_ids: Box<[_]> = Box::new([$(TypeId::of::<$type>(),)+]);
+                let mut type_ids: Box<[_]> = Box::new([$(TypeId::of::<$type>().into(),)+]);
 
                 type_ids.sort_unstable();
                 let type_ids: Arc<[_]> = type_ids.into();

--- a/src/remove.rs
+++ b/src/remove.rs
@@ -106,9 +106,9 @@ macro_rules! impl_remove {
             fn try_remove(self, entity: EntityId) -> Result<<($($type,)+) as Removable>::Out, error::Remove> {
                 // non packed storages should not pay the price of pack
                 if $(core::mem::discriminant(&self.$index.pack_info.pack) != core::mem::discriminant(&Pack::NoPack) || !self.$index.pack_info.observer_types.is_empty())||+ {
-                    let mut types = [$(TypeId::of::<$type>()),+];
+                    let mut types = [$(TypeId::of::<$type>().into()),+];
                     types.sort_unstable();
-                    let mut add_types = [$(TypeId::of::<$add_type>()),*];
+                    let mut add_types = [$(TypeId::of::<$add_type>().into()),*];
                     add_types.sort_unstable();
 
                     let mut should_unpack = Vec::with_capacity(types.len() + add_types.len());
@@ -132,7 +132,7 @@ macro_rules! impl_remove {
                     )+
 
                     $(
-                        if should_unpack.contains(&TypeId::of::<$add_type>()) {
+                        if should_unpack.contains(&TypeId::of::<$add_type>().into()) {
                             self.$add_index.unpack(entity);
                         }
                     )*

--- a/src/sparse_set/add_component.rs
+++ b/src/sparse_set/add_component.rs
@@ -1,6 +1,6 @@
 use crate::error;
 use crate::sparse_set::Pack;
-use crate::storage::EntityId;
+use crate::storage::{EntityId, StorageId};
 use crate::view::ViewMut;
 use alloc::vec::Vec;
 use core::any::{type_name, TypeId};
@@ -96,24 +96,24 @@ macro_rules! impl_add_component_unchecked {
                     let mut should_pack = Vec::new();
                     // non packed storages should not pay the price of pack
                     if $(core::mem::discriminant(&self.$index.pack_info.pack) != core::mem::discriminant(&Pack::NoPack) || !self.$index.pack_info.observer_types.is_empty())||+ {
-                        let mut type_ids = [$(TypeId::of::<$type>()),+];
-                        type_ids.sort_unstable();
-                        let mut add_types = [$(TypeId::of::<$add_type>()),*];
+                        let mut storage_ids = [$(StorageId::TypeId(TypeId::of::<$type>().into())),+];
+                        storage_ids.sort_unstable();
+                        let mut add_types = [$(TypeId::of::<$add_type>().into()),*];
                         add_types.sort_unstable();
-                        let mut real_types = Vec::with_capacity(type_ids.len() + add_types.len());
-                        real_types.extend_from_slice(&type_ids);
+                        let mut real_types = Vec::with_capacity(storage_ids.len() + add_types.len());
+                        real_types.extend_from_slice(&storage_ids);
 
                         $(
                             if self.$add_index.contains(entity) {
-                                real_types.push(TypeId::of::<$add_type>());
+                                real_types.push(TypeId::of::<$add_type>().into());
                             }
                         )*
                         real_types.sort_unstable();
 
                         should_pack.reserve(real_types.len());
                         $(
-                            if self.$index.pack_info.has_all_storages(&type_ids, &add_types) {
-                                if !should_pack.contains(&TypeId::of::<$type>()) {
+                            if self.$index.pack_info.has_all_storages(&storage_ids, &add_types) {
+                                if !should_pack.contains(&TypeId::of::<$type>().into()) {
                                     match &self.$index.pack_info.pack {
                                         Pack::Tight(pack) => if let Ok(types) = pack.is_packable(&real_types) {
                                             should_pack.extend_from_slice(types);
@@ -131,7 +131,7 @@ macro_rules! impl_add_component_unchecked {
                         )+
 
                         $(
-                            if should_pack.contains(&TypeId::of::<$add_type>()) {
+                            if should_pack.contains(&TypeId::of::<$add_type>().into()) {
                                 self.$add_index.pack(entity);
                             }
                         )*
@@ -139,7 +139,7 @@ macro_rules! impl_add_component_unchecked {
 
                     $(
                         self.$index.insert(component.$index, entity);
-                        if should_pack.contains(&TypeId::of::<$type>()) {
+                        if should_pack.contains(&TypeId::of::<$type>().into()) {
                             self.$index.pack(entity);
                         }
                     )+

--- a/src/sparse_set/mod.rs
+++ b/src/sparse_set/mod.rs
@@ -14,11 +14,11 @@ pub(crate) use view_add_entity::ViewAddEntity;
 pub(crate) use windows::RawWindowMut;
 
 use crate::error;
-use crate::storage::EntityId;
+use crate::storage::{EntityId, StorageId};
 use crate::unknown_storage::UnknownStorage;
 use alloc::boxed::Box;
 use alloc::vec::Vec;
-use core::any::{type_name, Any, TypeId};
+use core::any::{type_name, Any};
 use core::ptr;
 
 pub(crate) const BUCKET_SIZE: usize = 128 / core::mem::size_of::<usize>();
@@ -1116,7 +1116,7 @@ impl<T> core::ops::IndexMut<EntityId> for SparseSet<T> {
 }
 
 impl<T: 'static> UnknownStorage for SparseSet<T> {
-    fn delete(&mut self, entity: EntityId, storage_to_unpack: &mut Vec<TypeId>) {
+    fn delete(&mut self, entity: EntityId, storage_to_unpack: &mut Vec<StorageId>) {
         self.actual_delete(entity);
 
         storage_to_unpack.reserve(self.pack_info.observer_types.len());

--- a/src/sparse_set/sort/unstable.rs
+++ b/src/sparse_set/sort/unstable.rs
@@ -81,18 +81,18 @@ macro_rules! impl_unstable_sort {
                     None,
                 }
 
-                let mut type_ids = [$(TypeId::of::<$type>()),+];
-                type_ids.sort_unstable();
+                let mut storage_ids = [$(TypeId::of::<$type>().into()),+];
+                storage_ids.sort_unstable();
                 let mut pack_sort = PackSort::None;
 
                 $({
                     if let PackSort::None = pack_sort {
                         match &self.$index.pack_info.pack {
                             Pack::Tight(pack) => {
-                                if let Ok(types) = pack.is_packable(&type_ids) {
-                                    if types.len() == type_ids.len() {
+                                if let Ok(types) = pack.is_packable(&storage_ids) {
+                                    if types.len() == storage_ids.len() {
                                         pack_sort = PackSort::Tight(pack.len);
-                                    } else if types.len() < type_ids.len() {
+                                    } else if types.len() < storage_ids.len() {
                                         return Err(error::Sort::TooManyStorages);
                                     } else {
                                         return Err(error::Sort::MissingPackStorage);
@@ -102,10 +102,10 @@ macro_rules! impl_unstable_sort {
                                 }
                             }
                             Pack::Loose(pack) => {
-                                if pack.is_packable(&type_ids).is_ok() {
-                                    if pack.tight_types.len() + pack.loose_types.len() == type_ids.len() {
+                                if pack.is_packable(&storage_ids).is_ok() {
+                                    if pack.tight_types.len() + pack.loose_types.len() == storage_ids.len() {
                                         pack_sort = PackSort::Loose(pack.len);
-                                    } else if pack.tight_types.len() + pack.loose_types.len() < type_ids.len() {
+                                    } else if pack.tight_types.len() + pack.loose_types.len() < storage_ids.len() {
                                         return Err(error::Sort::TooManyStorages);
                                     } else {
                                         return Err(error::Sort::MissingPackStorage);

--- a/src/sparse_set/view_add_entity.rs
+++ b/src/sparse_set/view_add_entity.rs
@@ -39,13 +39,13 @@ macro_rules! impl_view_add_entity {
                     sparse_sets.$index.insert(component.$index, entity);
                 )+
 
-                let type_ids = [$(TypeId::of::<$type>()),+];
-                let mut sorted_type_ids = type_ids.clone();
+                let storage_ids = [$(TypeId::of::<$type>().into()),+];
+                let mut sorted_type_ids = storage_ids.clone();
                 sorted_type_ids.sort_unstable();
 
-                let mut should_pack = Vec::with_capacity(type_ids.len());
+                let mut should_pack = Vec::with_capacity(storage_ids.len());
                 $(
-                    let type_id = type_ids[$index];
+                    let type_id = storage_ids[$index];
 
                     if should_pack.contains(&type_id) {
                         sparse_sets.$index.pack(entity);

--- a/src/storage/all/delete_any.rs
+++ b/src/storage/all/delete_any.rs
@@ -14,7 +14,7 @@ impl<T: 'static> DeleteAny for (T,) {
     fn delete_any(all_storages: &mut AllStorages) {
         // we have an exclusive reference so it's ok to not lock and still get a reference
         let storages = unsafe { &*all_storages.storages.get() };
-        if let Some(storage) = storages.get(&TypeId::of::<T>()) {
+        if let Some(storage) = storages.get(&TypeId::of::<T>().into()) {
             if let Ok(mut sparse_set) = storage.sparse_set_mut::<T>() {
                 let ids = sparse_set.dense.clone();
                 sparse_set.clear();
@@ -36,7 +36,7 @@ macro_rules! impl_delete_any {
                 let mut ids: HashSet<EntityId, BuildHasherDefault<TypeIdHasher>> = HashSet::default();
 
                 $(
-                    if let Some(storage) = storages.get(&TypeId::of::<$type>()) {
+                    if let Some(storage) = storages.get(&TypeId::of::<$type>().into()) {
                         if let Ok(mut sparse_set) = storage.sparse_set_mut::<$type>() {
                             ids.extend(&sparse_set.dense);
                             sparse_set.clear();

--- a/src/storage/all/mod.rs
+++ b/src/storage/all/mod.rs
@@ -100,8 +100,8 @@ impl AllStorages {
     }
     pub(crate) fn sparse_set<T: 'static + Send + Sync>(
         &self,
+        storage_id: StorageId,
     ) -> Result<Ref<'_, SparseSet<T>>, error::GetStorage> {
-        let storage_id = TypeId::of::<T>().into();
         {
             self.lock.lock_shared();
             // SAFE we locked
@@ -126,8 +126,8 @@ impl AllStorages {
     }
     pub(crate) fn sparse_set_mut<T: 'static + Send + Sync>(
         &self,
+        storage_id: StorageId,
     ) -> Result<RefMut<'_, SparseSet<T>>, error::GetStorage> {
-        let storage_id = TypeId::of::<T>().into();
         {
             self.lock.lock_shared();
             // SAFE we locked

--- a/src/storage/entity/add_component.rs
+++ b/src/storage/entity/add_component.rs
@@ -68,24 +68,24 @@ macro_rules! impl_add_component {
                     let mut should_pack = Vec::new();
                     // non packed storages should not pay the price of pack
                     if $(core::mem::discriminant(&self.$index.pack_info.pack) != core::mem::discriminant(&Pack::NoPack) || !self.$index.pack_info.observer_types.is_empty())||+ {
-                        let mut type_ids = [$(TypeId::of::<$type>()),+];
-                        type_ids.sort_unstable();
-                        let mut add_types = [$(TypeId::of::<$add_type>()),*];
+                        let mut storage_ids = [$(TypeId::of::<$type>().into()),+];
+                        storage_ids.sort_unstable();
+                        let mut add_types = [$(TypeId::of::<$add_type>().into()),*];
                         add_types.sort_unstable();
-                        let mut real_types = Vec::with_capacity(type_ids.len() + add_types.len());
-                        real_types.extend_from_slice(&type_ids);
+                        let mut real_types = Vec::with_capacity(storage_ids.len() + add_types.len());
+                        real_types.extend_from_slice(&storage_ids);
 
                         $(
                             if self.$add_index.contains(entity) {
-                                real_types.push(TypeId::of::<$add_type>());
+                                real_types.push(TypeId::of::<$add_type>().into());
                             }
                         )*
                         real_types.sort_unstable();
 
                         should_pack.reserve(real_types.len());
                         $(
-                            if self.$index.pack_info.has_all_storages(&type_ids, &add_types) {
-                                if !should_pack.contains(&TypeId::of::<$type>()) {
+                            if self.$index.pack_info.has_all_storages(&storage_ids, &add_types) {
+                                if !should_pack.contains(&TypeId::of::<$type>().into()) {
                                     match &self.$index.pack_info.pack {
                                         Pack::Tight(pack) => if let Ok(types) = pack.is_packable(&real_types) {
                                             should_pack.extend_from_slice(types);
@@ -103,7 +103,7 @@ macro_rules! impl_add_component {
                         )+
 
                         $(
-                            if should_pack.contains(&TypeId::of::<$add_type>()) {
+                            if should_pack.contains(&TypeId::of::<$add_type>().into()) {
                                 self.$add_index.pack(entity);
                             }
                         )*
@@ -111,7 +111,7 @@ macro_rules! impl_add_component {
 
                     $(
                         self.$index.insert(component.$index, entity);
-                        if should_pack.contains(&TypeId::of::<$type>()) {
+                        if should_pack.contains(&TypeId::of::<$type>().into()) {
                             self.$index.pack(entity);
                         }
                     )+

--- a/src/storage/entity/mod.rs
+++ b/src/storage/entity/mod.rs
@@ -7,10 +7,11 @@ pub use iterator::EntitiesIter;
 
 use crate::error;
 use crate::sparse_set::ViewAddEntity;
+use crate::storage::StorageId;
 use crate::unknown_storage::UnknownStorage;
 use add_component::AddComponent;
 use alloc::vec::Vec;
-use core::any::{Any, TypeId};
+use core::any::Any;
 
 /// Entities holds the EntityIds to all entities: living, removed and dead.
 ///
@@ -191,7 +192,7 @@ impl Entities {
 }
 
 impl UnknownStorage for Entities {
-    fn delete(&mut self, _entity: EntityId, _: &mut Vec<TypeId>) {}
+    fn delete(&mut self, _entity: EntityId, _: &mut Vec<StorageId>) {}
     fn clear(&mut self) {
         if self.data.is_empty() {
             return;

--- a/src/storage/unique.rs
+++ b/src/storage/unique.rs
@@ -1,12 +1,13 @@
 use crate::storage::EntityId;
+use crate::storage::StorageId;
 use crate::unknown_storage::UnknownStorage;
 use alloc::vec::Vec;
-use core::any::{Any, TypeId};
+use core::any::Any;
 
 pub(super) struct Unique<T>(pub(crate) T);
 
 impl<T: 'static> UnknownStorage for Unique<T> {
-    fn delete(&mut self, _: EntityId, _: &mut Vec<TypeId>) {}
+    fn delete(&mut self, _: EntityId, _: &mut Vec<StorageId>) {}
     fn clear(&mut self) {}
     fn unpack(&mut self, _: EntityId) {}
     fn any(&self) -> &dyn Any {

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -6,9 +6,8 @@ use crate::atomic_refcell::AtomicRefCell;
 use crate::borrow::Borrow;
 use crate::borrow::Mutation;
 use crate::error;
-use crate::storage::AllStorages;
+use crate::storage::{AllStorages, StorageId};
 use alloc::vec::Vec;
-use core::any::TypeId;
 
 pub struct Nothing;
 
@@ -19,7 +18,7 @@ pub trait System<'s, Data, B, R> {
         #[cfg(feature = "parallel")] thread_pool: &'s rayon::ThreadPool,
     ) -> Result<B, error::GetStorage>;
 
-    fn borrow_infos(infos: &mut Vec<(TypeId, Mutation)>);
+    fn borrow_infos(infos: &mut Vec<(StorageId, Mutation)>);
 
     fn is_send_sync() -> bool;
 }
@@ -39,7 +38,7 @@ where
         Ok(Nothing)
     }
 
-    fn borrow_infos(_: &mut Vec<(TypeId, Mutation)>) {}
+    fn borrow_infos(_: &mut Vec<(StorageId, Mutation)>) {}
 
     fn is_send_sync() -> bool {
         true
@@ -61,7 +60,7 @@ where
         Ok(Nothing)
     }
 
-    fn borrow_infos(_: &mut Vec<(TypeId, Mutation)>) {}
+    fn borrow_infos(_: &mut Vec<(StorageId, Mutation)>) {}
 
     fn is_send_sync() -> bool {
         true
@@ -87,7 +86,7 @@ macro_rules! impl_system {
                     Ok(($($type::try_borrow(all_storages)?,)+))
                 }
             }
-            fn borrow_infos(infos: &mut Vec<(TypeId, Mutation)>) {
+            fn borrow_infos(infos: &mut Vec<(StorageId, Mutation)>) {
                 $(
                     $type::borrow_infos(infos);
                 )+
@@ -116,7 +115,7 @@ macro_rules! impl_system {
                     Ok(($($type::try_borrow(all_storages)?,)+))
                 }
             }
-            fn borrow_infos(infos: &mut Vec<(TypeId, Mutation)>) {
+            fn borrow_infos(infos: &mut Vec<(StorageId, Mutation)>) {
                 $(
                     $type::borrow_infos(infos);
                 )+

--- a/src/unknown_storage.rs
+++ b/src/unknown_storage.rs
@@ -1,11 +1,10 @@
 use crate::sparse_set::SparseSet;
-use crate::storage::Entities;
-use crate::storage::EntityId;
+use crate::storage::{Entities, EntityId, StorageId};
 use alloc::vec::Vec;
-use core::any::{Any, TypeId};
+use core::any::Any;
 
 pub(super) trait UnknownStorage {
-    fn delete(&mut self, entity: EntityId, storage_to_unpack: &mut Vec<TypeId>);
+    fn delete(&mut self, entity: EntityId, storage_to_unpack: &mut Vec<StorageId>);
     fn clear(&mut self);
     fn unpack(&mut self, entity: EntityId);
     fn any(&self) -> &dyn Any;

--- a/src/world/mod.rs
+++ b/src/world/mod.rs
@@ -578,16 +578,12 @@ world.try_run_with_data(sys1, (EntityId::dead(), [0., 0.])).unwrap();
         s: S,
         data: Data,
     ) -> Result<R, error::Run> {
-        Ok(s.run((data,), {
-            #[cfg(feature = "parallel")]
-            {
-                S::try_borrow(&self.all_storages, &self.thread_pool)?
-            }
-            #[cfg(not(feature = "parallel"))]
-            {
-                S::try_borrow(&self.all_storages)?
-            }
-        }))
+        #[cfg(feature = "parallel")]
+        let borrow = s.try_borrow(&self.all_storages, &self.thread_pool)?;
+        #[cfg(not(feature = "parallel"))]
+        let borrow = s.try_borrow(&self.all_storages)?;
+
+        Ok(s.run((data,), borrow))
     }
     #[doc = "Borrows the requested storages and runs the function.  
 Data can be passed to the function, this always has to be a single type but you can use a tuple if needed.  
@@ -844,16 +840,12 @@ let i = world.try_run(sys1).unwrap();
         &'s self,
         s: S,
     ) -> Result<R, error::Run> {
-        Ok(s.run((), {
-            #[cfg(feature = "parallel")]
-            {
-                S::try_borrow(&self.all_storages, &self.thread_pool)?
-            }
-            #[cfg(not(feature = "parallel"))]
-            {
-                S::try_borrow(&self.all_storages)?
-            }
-        }))
+        #[cfg(feature = "parallel")]
+        let borrow = s.try_borrow(&self.all_storages, &self.thread_pool)?;
+        #[cfg(not(feature = "parallel"))]
+        let borrow = s.try_borrow(&self.all_storages)?;
+
+        Ok(s.run((), borrow))
     }
     #[doc = "Borrows the requested storages and runs the function.  
 Unwraps errors.

--- a/src/world/scheduler/builder.rs
+++ b/src/world/scheduler/builder.rs
@@ -93,10 +93,10 @@ impl<'a> WorkloadBuilder<'a> {
         S: Fn(&World) -> Result<(), error::Run> + Send + Sync + 'static,
     >(
         mut self,
-        (system, _): (S, F),
+        (system, f): (S, F),
     ) -> Result<WorkloadBuilder<'a>, error::InvalidSystem> {
         let old_len = self.borrow_info.len();
-        F::borrow_infos(&mut self.borrow_info);
+        f.borrow_infos(&mut self.borrow_info);
 
         let borrows = &self.borrow_info[old_len..];
 
@@ -125,7 +125,7 @@ impl<'a> WorkloadBuilder<'a> {
             }
         }
 
-        let is_send_sync = F::is_send_sync();
+        let is_send_sync = f.is_send_sync();
         self.systems.push((
             core::any::TypeId::of::<S>().into(),
             type_name::<F>(),

--- a/src/world/scheduler/mod.rs
+++ b/src/world/scheduler/mod.rs
@@ -3,11 +3,11 @@ mod builder;
 pub use builder::WorkloadBuilder;
 
 use crate::error;
+use crate::storage::StorageId;
 use crate::World;
 use alloc::borrow::Cow;
 use alloc::boxed::Box;
 use alloc::vec::Vec;
-use core::any::TypeId;
 use core::ops::Range;
 use hashbrown::HashMap;
 
@@ -15,7 +15,7 @@ use hashbrown::HashMap;
 pub(crate) struct Scheduler {
     pub(super) systems: Vec<Box<dyn Fn(&World) -> Result<(), error::Run> + Send + Sync + 'static>>,
     pub(super) system_names: Vec<&'static str>,
-    pub(super) lookup_table: HashMap<TypeId, usize>,
+    pub(super) lookup_table: HashMap<StorageId, usize>,
     // a batch lists systems that can run in parallel
     pub(super) batch: Vec<Box<[usize]>>,
     pub(super) workloads: HashMap<Cow<'static, str>, Range<usize>>,


### PR DESCRIPTION
Hey there :wave: 

Here's a PR that attempts to migrate from using `TypeId` to using `StorageId` in an effort to start to address #96.

I may have missed a spot here or there, and this doesn't address anything an API change to facilitate creating custom components yet ( necessarily ) it just switches everything I could find that should take a `StorageId` instead of a `TypeId`.

Definitely needs some review, but all of the tests pass.