### PR TITLE
Add From instance to go from EntityId -> u64

### DIFF
--- a/src/storage/entity/entity_id/mod.rs
+++ b/src/storage/entity/entity_id/mod.rs
@@ -116,6 +116,12 @@ impl core::fmt::Debug for EntityId {
     }
 }
 
+impl From<EntityId> for u64 {
+    fn from(EntityId(id): EntityId) -> Self {
+        id.get()
+    }
+}
+
 #[test]
 fn entity_id() {
     let mut entity_id = EntityId::new(0);
@@ -132,4 +138,5 @@ fn entity_id() {
     entity_id.set_index(554);
     assert_eq!(entity_id.index(), 554);
     assert_eq!(entity_id.gen(), 3);
+    assert_eq!(entity_id.0.get(), entity_id.into());
 }


### PR DESCRIPTION
This adds a trivial instance so that EntityIds can be inspected by code outside of the shipyard crate without having to do something gnarly like serializing with serde and deserializing into a u64.

This intentionally doesn't add any way for code outside of shipyard itself to create `EntityId`s since that would violate some assumptions that are needed for safety.