### PR TITLE
update systems in guide to discuss passing in data

### DIFF
--- a/guide/src/fundamentals/systems.md
+++ b/guide/src/fundamentals/systems.md
@@ -1,7 +1,7 @@
 # Systems
 
-Systems are a great way to organize code.
-A function only taking views as arguments is all you need.
+Systems are a great way to organize code.  
+A function with views as arguments is all you need.
 
 Here's an example:
 ```rust, noplaypen
@@ -18,19 +18,30 @@ world.run(create_ints);
 
 ### Passing Data to Systems
 
-The first argument doesn't have to be a view, you can pass any data to a
-system. You don't even have to own it. 
+The first argument doesn't have to be a view, you can pass any data to a system. You don't even have to own it. 
 
 ```rust, noplaypen
-fn in_acid(season: &Season, positions: View<Position>, mut healths:
-ViewMut<Health>) {
+fn in_acid(season: &Season, positions: View<Position>, mut healths: ViewMut<Health>) {
     // -- snip --
 }
 
 world.run_with_data(in_acid, &season);
 ```
-Note: we call `world.run_with_data()` instead of `world.run` when we want to
-pass data to a system.
+We call [`run_with_data`](https://docs.rs/shipyard/latest/shipyard/struct.World.html#method.run_with_data) instead of [`run`](https://docs.rs/shipyard/latest/shipyard/struct.World.html#method.run) when we want to pass data to a system.
+
+If you want to pass multiple variables, you can use a tuple.
+
+```rust, noplaypen
+fn in_acid(
+    (season, precipitation): (&Season, &Precipitation),
+    positions: View<Position>,
+    mut healths: ViewMut<Health>,
+) {
+    // -- snip --
+}
+
+world.run_with_data(in_acid, (&season, &precipitation));
+```
 
 ### Workloads
 

--- a/guide/src/fundamentals/systems.md
+++ b/guide/src/fundamentals/systems.md
@@ -16,6 +16,22 @@ We have a system, let's run it!
 world.run(create_ints);
 ```
 
+### Passing Data to Systems
+
+The first argument doesn't have to be a view, you can pass any data to a
+system. You don't even have to own it. 
+
+```rust, noplaypen
+fn in_acid(season: &Season, positions: View<Position>, mut healths:
+ViewMut<Health>) {
+    // -- snip --
+}
+
+world.run_with_data(in_acid, &season);
+```
+Note: we call `world.run_with_data()` instead of `world.run` when we want to
+pass data to a system.
+
 ### Workloads
 
 A workload is a group of one or more systems that is assigned a name.  


### PR DESCRIPTION
Minor documentation PR; I noticed the README info on how to pass data into a system was not in the Guide. So I copied that text and added a sentence pointing out to use `run_with_data`. 