### PR TITLE
Add Optional Borrows

### DIFF
--- a/src/borrow/all_storages.rs
+++ b/src/borrow/all_storages.rs
@@ -145,6 +145,12 @@ impl<'a, T: 'static> AllStoragesBorrow<'a> for NonSendSync<UniqueViewMut<'a, T>>
     }
 }
 
+impl<'a, T: AllStoragesBorrow<'a>> AllStoragesBorrow<'a> for Option<T> {
+    fn try_borrow(all_storages: &'a AllStorages) -> Result<Self, error::GetStorage> {
+        Ok(T::try_borrow(all_storages).ok())
+    }
+}
+
 macro_rules! impl_all_storages_borrow {
     ($(($type: ident, $index: tt))+) => {
         impl<'a, $($type: AllStoragesBorrow<'a>),+> AllStoragesBorrow<'a> for ($($type,)+) {

--- a/src/storage/all/mod.rs
+++ b/src/storage/all/mod.rs
@@ -544,7 +544,8 @@ You can use:
 * [EntitiesView] for a shared access to the entity storage
 * [EntitiesViewMut] for an exclusive reference to the entity storage
 * [UniqueView]\\<T\\> for a shared access to a `T` unique storage
-* [UniqueViewMut]\\<T\\> for an exclusive access to a `T` unique storage"]
+* [UniqueViewMut]\\<T\\> for an exclusive access to a `T` unique storage
+* `Option<V>` with one or multiple views for fallible access to one or more storages"]
     #[cfg_attr(
         all(feature = "non_send", docsrs),
         doc = "* <span style=\"display: table;color: #2f2f2f;background-color: #C4ECFF;border-width: 1px;border-style: solid;border-color: #7BA5DB;padding: 3px;margin-bottom: 5px; font-size: 90%\">This is supported on <strong><code style=\"background-color: #C4ECFF\">feature=\"non_send\"</code></strong> only:</span>"
@@ -643,7 +644,8 @@ You can use:
 * [EntitiesView] for a shared access to the entity storage
 * [EntitiesViewMut] for an exclusive reference to the entity storage
 * [UniqueView]\\<T\\> for a shared access to a `T` unique storage
-* [UniqueViewMut]\\<T\\> for an exclusive access to a `T` unique storage"]
+* [UniqueViewMut]\\<T\\> for an exclusive access to a `T` unique storage
+* `Option<V>` with one or multiple views for fallible access to one or more storages"]
     #[cfg_attr(
         all(feature = "non_send", docsrs),
         doc = "* <span style=\"display: table;color: #2f2f2f;background-color: #C4ECFF;border-width: 1px;border-style: solid;border-color: #7BA5DB;padding: 3px;margin-bottom: 5px; font-size: 90%\">This is supported on <strong><code style=\"background-color: #C4ECFF\">feature=\"non_send\"</code></strong> only:</span>"
@@ -741,7 +743,8 @@ You can use:
 * [EntitiesView] for a shared access to the entity storage
 * [EntitiesViewMut] for an exclusive reference to the entity storage
 * [UniqueView]\\<T\\> for a shared access to a `T` unique storage
-* [UniqueViewMut]\\<T\\> for an exclusive access to a `T` unique storage"]
+* [UniqueViewMut]\\<T\\> for an exclusive access to a `T` unique storage
+* `Option<V>` with one or multiple views for fallible access to one or more storages"]
     #[cfg_attr(
         all(feature = "non_send", docsrs),
         doc = "* <span style=\"display: table;color: #2f2f2f;background-color: #C4ECFF;border-width: 1px;border-style: solid;border-color: #7BA5DB;padding: 3px;margin-bottom: 5px; font-size: 90%\">This is supported on <strong><code style=\"background-color: #C4ECFF\">feature=\"non_send\"</code></strong> only:</span>"
@@ -833,7 +836,8 @@ You can use:
 * [EntitiesView] for a shared access to the entity storage
 * [EntitiesViewMut] for an exclusive reference to the entity storage
 * [UniqueView]\\<T\\> for a shared access to a `T` unique storage
-* [UniqueViewMut]\\<T\\> for an exclusive access to a `T` unique storage"]
+* [UniqueViewMut]\\<T\\> for an exclusive access to a `T` unique storage
+* `Option<V>` with one or multiple views for fallible access to one or more storages"]
     #[cfg_attr(
         all(feature = "non_send", docsrs),
         doc = "* <span style=\"display: table;color: #2f2f2f;background-color: #C4ECFF;border-width: 1px;border-style: solid;border-color: #7BA5DB;padding: 3px;margin-bottom: 5px; font-size: 90%\">This is supported on <strong><code style=\"background-color: #C4ECFF\">feature=\"non_send\"</code></strong> only:</span>"
@@ -925,7 +929,8 @@ You can use:
 * [EntitiesView] for a shared access to the entity storage
 * [EntitiesViewMut] for an exclusive reference to the entity storage
 * [UniqueView]\\<T\\> for a shared access to a `T` unique storage
-* [UniqueViewMut]\\<T\\> for an exclusive access to a `T` unique storage"]
+* [UniqueViewMut]\\<T\\> for an exclusive access to a `T` unique storage
+* `Option<V>` with one or multiple views for fallible access to one or more storages"]
     #[cfg_attr(
         all(feature = "non_send", docsrs),
         doc = "* <span style=\"display: table;color: #2f2f2f;background-color: #C4ECFF;border-width: 1px;border-style: solid;border-color: #7BA5DB;padding: 3px;margin-bottom: 5px; font-size: 90%\">This is supported on <strong><code style=\"background-color: #C4ECFF\">feature=\"non_send\"</code></strong> only:</span>"
@@ -1032,7 +1037,8 @@ You can use:
 * [EntitiesView] for a shared access to the entity storage
 * [EntitiesViewMut] for an exclusive reference to the entity storage
 * [UniqueView]\\<T\\> for a shared access to a `T` unique storage
-* [UniqueViewMut]\\<T\\> for an exclusive access to a `T` unique storage"]
+* [UniqueViewMut]\\<T\\> for an exclusive access to a `T` unique storage
+* `Option<V>` with one or multiple views for fallible access to one or more storages"]
     #[cfg_attr(
         all(feature = "non_send", docsrs),
         doc = "* <span style=\"display: table;color: #2f2f2f;background-color: #C4ECFF;border-width: 1px;border-style: solid;border-color: #7BA5DB;padding: 3px;margin-bottom: 5px; font-size: 90%\">This is supported on <strong><code style=\"background-color: #C4ECFF\">feature=\"non_send\"</code></strong> only:</span>"

--- a/src/world/mod.rs
+++ b/src/world/mod.rs
@@ -225,7 +225,8 @@ You can use:
 * [EntitiesViewMut] for an exclusive reference to the entity storage
 * [AllStoragesViewMut] for an exclusive access to the storage of all components, ⚠️ can't coexist with any other storage borrow
 * [UniqueView]\\<T\\> for a shared access to a `T` unique storage
-* [UniqueViewMut]\\<T\\> for an exclusive access to a `T` unique storage"]
+* [UniqueViewMut]\\<T\\> for an exclusive access to a `T` unique storage
+* `Option<V>` with one or multiple views for fallible access to one or more storages"]
     #[cfg_attr(
         all(feature = "parallel", docsrs),
         doc = "* <span style=\"display: table;color: #2f2f2f;background-color: #C4ECFF;border-width: 1px;border-style: solid;border-color: #7BA5DB;padding: 3px;margin-bottom: 5px; font-size: 90%\">This is supported on <strong><code style=\"background-color: #C4ECFF\">feature=\"parallel\"</code></strong> only:</span>"
@@ -352,7 +353,8 @@ You can use:
 * [EntitiesViewMut] for an exclusive reference to the entity storage
 * [AllStoragesViewMut] for an exclusive access to the storage of all components, ⚠️ can't coexist with any other storage borrow
 * [UniqueView]\\<T\\> for a shared access to a `T` unique storage
-* [UniqueViewMut]\\<T\\> for an exclusive access to a `T` unique storage"]
+* [UniqueViewMut]\\<T\\> for an exclusive access to a `T` unique storage
+* `Option<V>` with one or multiple views for fallible access to one or more storages"]
     #[cfg_attr(
         all(feature = "parallel", docsrs),
         doc = "* <span style=\"display: table;color: #2f2f2f;background-color: #C4ECFF;border-width: 1px;border-style: solid;border-color: #7BA5DB;padding: 3px;margin-bottom: 5px; font-size: 90%\">This is supported on <strong><code style=\"background-color: #C4ECFF\">feature=\"parallel\"</code></strong> only:</span>"
@@ -471,7 +473,8 @@ You can use:
 * [EntitiesViewMut] for an exclusive reference to the entity storage
 * [AllStoragesViewMut] for an exclusive access to the storage of all components, ⚠️ can't coexist with any other storage borrow
 * [UniqueView]\\<T\\> for a shared access to a `T` unique storage
-* [UniqueViewMut]\\<T\\> for an exclusive access to a `T` unique storage"]
+* [UniqueViewMut]\\<T\\> for an exclusive access to a `T` unique storage
+* `Option<V>` with one or multiple views for fallible access to one or more storages"]
     #[cfg_attr(
         all(feature = "parallel", docsrs),
         doc = "* <span style=\"display: table;color: #2f2f2f;background-color: #C4ECFF;border-width: 1px;border-style: solid;border-color: #7BA5DB;padding: 3px;margin-bottom: 5px; font-size: 90%\">This is supported on <strong><code style=\"background-color: #C4ECFF\">feature=\"parallel\"</code></strong> only:</span>"
@@ -607,7 +610,8 @@ You can use:
 * [EntitiesViewMut] for an exclusive reference to the entity storage
 * [AllStoragesViewMut] for an exclusive access to the storage of all components, ⚠️ can't coexist with any other storage borrow
 * [UniqueView]\\<T\\> for a shared access to a `T` unique storage
-* [UniqueViewMut]\\<T\\> for an exclusive access to a `T` unique storage"]
+* [UniqueViewMut]\\<T\\> for an exclusive access to a `T` unique storage
+* `Option<V>` with one or multiple views for fallible access to one or more storages"]
     #[cfg_attr(
         all(feature = "parallel", docsrs),
         doc = "* <span style=\"display: table;color: #2f2f2f;background-color: #C4ECFF;border-width: 1px;border-style: solid;border-color: #7BA5DB;padding: 3px;margin-bottom: 5px; font-size: 90%\">This is supported on <strong><code style=\"background-color: #C4ECFF\">feature=\"parallel\"</code></strong> only:</span>"
@@ -734,7 +738,8 @@ You can use:
 * [EntitiesViewMut] for an exclusive reference to the entity storage
 * [AllStoragesViewMut] for an exclusive access to the storage of all components, ⚠️ can't coexist with any other storage borrow
 * [UniqueView]\\<T\\> for a shared access to a `T` unique storage
-* [UniqueViewMut]\\<T\\> for an exclusive access to a `T` unique storage"]
+* [UniqueViewMut]\\<T\\> for an exclusive access to a `T` unique storage
+* `Option<V>` with one or multiple views for fallible access to one or more storages"]
     #[cfg_attr(
         all(feature = "parallel", docsrs),
         doc = "* <span style=\"display: table;color: #2f2f2f;background-color: #C4ECFF;border-width: 1px;border-style: solid;border-color: #7BA5DB;padding: 3px;margin-bottom: 5px; font-size: 90%\">This is supported on <strong><code style=\"background-color: #C4ECFF\">feature=\"parallel\"</code></strong> only:</span>"
@@ -872,7 +877,8 @@ You can use:
 * [EntitiesViewMut] for an exclusive reference to the entity storage
 * [AllStoragesViewMut] for an exclusive access to the storage of all components, ⚠️ can't coexist with any other storage borrow
 * [UniqueView]\\<T\\> for a shared access to a `T` unique storage
-* [UniqueViewMut]\\<T\\> for an exclusive access to a `T` unique storage"]
+* [UniqueViewMut]\\<T\\> for an exclusive access to a `T` unique storage
+* `Option<V>` with one or multiple views for fallible access to one or more storages"]
     #[cfg_attr(
         all(feature = "parallel", docsrs),
         doc = "* <span style=\"display: table;color: #2f2f2f;background-color: #C4ECFF;border-width: 1px;border-style: solid;border-color: #7BA5DB;padding: 3px;margin-bottom: 5px; font-size: 90%\">This is supported on <strong><code style=\"background-color: #C4ECFF\">feature=\"parallel\"</code></strong> only:</span>"

--- a/tests/borrow/mod.rs
+++ b/tests/borrow/mod.rs
@@ -98,6 +98,21 @@ fn all_storages_double_borrow() {
 }
 
 #[test]
+fn all_storages_option_borrow() {
+    let world = World::new();
+    let all_storages = world.borrow::<AllStoragesViewMut>();
+
+    let u32s = all_storages.try_borrow::<Option<View<u32>>>().unwrap();
+
+    let u32s = u32s.unwrap();
+    assert_eq!(u32s.len(), 0);
+    drop(u32s);
+    let _i32s = all_storages.try_borrow::<ViewMut<i32>>().unwrap();
+    let other_i32s = all_storages.try_borrow::<Option<View<i32>>>().unwrap();
+    assert!(other_i32s.is_none());
+}
+
+#[test]
 #[cfg(feature = "non_send")]
 fn non_send_storage_in_other_thread() {
     let world = World::new();

--- a/tests/borrow/mod.rs
+++ b/tests/borrow/mod.rs
@@ -100,7 +100,7 @@ fn all_storages_double_borrow() {
 #[test]
 fn all_storages_option_borrow() {
     let world = World::new();
-    let all_storages = world.borrow::<AllStoragesViewMut>();
+    let all_storages = world.try_borrow::<AllStoragesViewMut>().unwrap();
 
     let u32s = all_storages.try_borrow::<Option<View<u32>>>().unwrap();
 

--- a/tests/borrow/mod.rs
+++ b/tests/borrow/mod.rs
@@ -27,6 +27,20 @@ fn simple_borrow() {
 }
 
 #[test]
+fn option_borrow() {
+    let world = World::new();
+
+    let u32s = world.try_borrow::<Option<View<u32>>>().unwrap();
+
+    let u32s = u32s.unwrap();
+    assert_eq!(u32s.len(), 0);
+    drop(u32s);
+    let _i32s = world.try_borrow::<ViewMut<i32>>().unwrap();
+    let other_i32s = world.try_borrow::<Option<View<i32>>>().unwrap();
+    assert!(other_i32s.is_none());
+}
+
+#[test]
 fn all_storages_simple_borrow() {
     let world = World::new();
 


### PR DESCRIPTION
Makes `Option<S: Borrow>`  implement `Borrow` itself. This is a nicer workaround for a case like this:
```rust
world.run(
    |
        definitely_need: View<Resource>,
        could_work_without: Option<View<OtherResource>>,
    | {
        if let Some(x) = could_work_without {
            // We have it
        } else {
            // We don't have it
        }
    }
);
```
In the case of `try_*` functions, they will only fail if the required resources in the system can't be accessed, since the `Option` resources will always succeed. 