### PR TITLE
remove clippy warnings for rust v1.48.0

### DIFF
--- a/src/sparse_set/mod.rs
+++ b/src/sparse_set/mod.rs
@@ -606,12 +606,8 @@ impl<T> SparseSet<T> {
         b: EntityId,
         f: F,
     ) -> Result<R, error::Apply> {
-        let a_index = self
-            .index_of(a)
-            .ok_or(error::Apply::MissingComponent(a))?;
-        let b_index = self
-            .index_of(b)
-            .ok_or(error::Apply::MissingComponent(b))?;
+        let a_index = self.index_of(a).ok_or(error::Apply::MissingComponent(a))?;
+        let b_index = self.index_of(b).ok_or(error::Apply::MissingComponent(b))?;
 
         if a_index != b_index {
             if self.metadata.update.is_some() {
@@ -663,12 +659,8 @@ impl<T> SparseSet<T> {
         b: EntityId,
         f: F,
     ) -> Result<R, error::Apply> {
-        let a_index = self
-            .index_of(a)
-            .ok_or(error::Apply::MissingComponent(a))?;
-        let b_index = self
-            .index_of(b)
-            .ok_or(error::Apply::MissingComponent(b))?;
+        let a_index = self.index_of(a).ok_or(error::Apply::MissingComponent(a))?;
+        let b_index = self.index_of(b).ok_or(error::Apply::MissingComponent(b))?;
 
         if a_index != b_index {
             if self.metadata.update.is_some() {

--- a/src/sparse_set/mod.rs
+++ b/src/sparse_set/mod.rs
@@ -608,10 +608,10 @@ impl<T> SparseSet<T> {
     ) -> Result<R, error::Apply> {
         let a_index = self
             .index_of(a)
-            .ok_or_else(|| error::Apply::MissingComponent(a))?;
+            .ok_or(error::Apply::MissingComponent(a))?;
         let b_index = self
             .index_of(b)
-            .ok_or_else(|| error::Apply::MissingComponent(b))?;
+            .ok_or(error::Apply::MissingComponent(b))?;
 
         if a_index != b_index {
             if self.metadata.update.is_some() {
@@ -665,10 +665,10 @@ impl<T> SparseSet<T> {
     ) -> Result<R, error::Apply> {
         let a_index = self
             .index_of(a)
-            .ok_or_else(|| error::Apply::MissingComponent(a))?;
+            .ok_or(error::Apply::MissingComponent(a))?;
         let b_index = self
             .index_of(b)
-            .ok_or_else(|| error::Apply::MissingComponent(b))?;
+            .ok_or(error::Apply::MissingComponent(b))?;
 
         if a_index != b_index {
             if self.metadata.update.is_some() {


### PR DESCRIPTION
**TL;DR**: use `ok_or` instead of `ok_or_else`


:wave: :cake: 