### PR TITLE
bump version to 0.5.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 name = "shipyard"
 readme = "README.md"
 repository = "https://github.com/leudz/shipyard"
-version = "0.4.0"
+version = "0.5.0"
 
 [workspace]
 members = ["bunny_demo", "tutorial"]


### PR DESCRIPTION
For some reason, the current master has 0.4.0, which is a yanked version. Since this may lead to confusion, let's just bump to the next version.