### PR TITLE
Support pretty-printed Debug for TypeInfo

### DIFF
--- a/src/scheduler/info.rs
+++ b/src/scheduler/info.rs
@@ -5,6 +5,8 @@ pub use crate::type_id::TypeId;
 use crate::borrow::Mutability;
 use crate::storage::StorageId;
 use alloc::borrow::Cow;
+use alloc::format;
+use alloc::string::ToString;
 use alloc::vec::Vec;
 
 /// Contains information related to a workload.
@@ -74,24 +76,18 @@ impl PartialEq<(TypeId, Mutability)> for TypeInfo {
 
 impl core::fmt::Debug for TypeInfo {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.write_str("TypeInfo {\n")?;
-        match (self.is_send, self.is_sync) {
-            (true, true) => f.write_fmt(format_args!("    name: {:?}\n", self.name))?,
-            (false, true) => f.write_fmt(format_args!(
-                "    name: \"shipyard::NonSend<{}>\"\n",
-                self.name
-            ))?,
-            (true, false) => f.write_fmt(format_args!(
-                "    name: \"shipyard::NonSync<{}>\"\n",
-                self.name
-            ))?,
-            (false, false) => f.write_fmt(format_args!(
-                "    name: \"shipyard::NonSendSync<{}>\"\n",
-                self.name
-            ))?,
-        }
-        f.write_fmt(format_args!("    mutability: {:?}\n", self.mutability))?;
-        f.write_fmt(format_args!("    storage_id: {:?}\n", self.storage_id))?;
-        f.write_str("}")
+        f.debug_struct("TypeInfo")
+            .field(
+                "name",
+                &match (self.is_send, self.is_sync) {
+                    (true, true) => self.name.to_string(),
+                    (false, true) => format!("shipyard::NonSend<{}>", self.name),
+                    (true, false) => format!("shipyard::NonSync<{}>", self.name),
+                    (false, false) => format!("shipyard::NonSendSync<{}>", self.name),
+                },
+            )
+            .field("mutability", &self.mutability)
+            .field("storage_id", &self.storage_id)
+            .finish()
     }
 }


### PR DESCRIPTION
Sample non-pretty printed:

> SystemInfo { name: \"web_author::plugins::page_plugins::tree_plugin::indexing::tree_indexing\", type_id: TypeId(3501623295016930637), borrow: [TypeInfo { name: \"shipyard::entities::Entities\", mutability: Shared, storage_id: TypeId(TypeId(10006243904426077102)) }, TypeInfo { name: \"shipyard::sparse_set::SparseSet<web_author::plugins::page_plugins::tree_plugin::node::ChildOf>\", mutability: Shared, storage_id: TypeId(TypeId(7227870938188220148)) }, TypeInfo { name: \"shipyard::sparse_set::SparseSet<web_author::plugins::page_plugins::tree_plugin::indexing::SiblingIndex>\", mutability: Exclusive, storage_id: TypeId(TypeId(5382654718418618064)) }, TypeInfo { name: \"shipyard::sparse_set::SparseSet<web_author::plugins::page_plugins::tree_plugin::indexing::ParentIndex>\", mutability: Exclusive, storage_id: TypeId(TypeId(9952275349462257484)) }], conflict: None },


Sample pretty-printed
![image](https://user-images.githubusercontent.com/2925395/104112050-f225fa00-52b7-11eb-8cbf-a793224c12dc.png)
(console.log doesn't copy-paste newlines correctly 😞 so this is screenshot)