### PR TITLE
Hide internals for update Storage wrappers

### DIFF
--- a/src/pack/update.rs
+++ b/src/pack/update.rs
@@ -1,7 +1,7 @@
 use crate::not::Not;
 
 #[derive(Clone)]
-pub struct Inserted<Storage>(pub Storage);
+pub struct Inserted<Storage>(pub(crate) Storage);
 
 impl<Storage> core::ops::Not for Inserted<Storage> {
     type Output = Not<Inserted<Storage>>;
@@ -12,7 +12,7 @@ impl<Storage> core::ops::Not for Inserted<Storage> {
 }
 
 #[derive(Clone)]
-pub struct Modified<Storage>(pub Storage);
+pub struct Modified<Storage>(pub(crate) Storage);
 
 impl<Storage> core::ops::Not for Modified<Storage> {
     type Output = Not<Modified<Storage>>;
@@ -22,7 +22,7 @@ impl<Storage> core::ops::Not for Modified<Storage> {
     }
 }
 #[derive(Clone)]
-pub struct InsertedOrModified<Storage>(pub Storage);
+pub struct InsertedOrModified<Storage>(pub(crate) Storage);
 
 impl<Storage> core::ops::Not for InsertedOrModified<Storage> {
     type Output = Not<InsertedOrModified<Storage>>;


### PR DESCRIPTION
I thought I might ask in Zulip, but it's easier to just open a PR with the suggestion.

I would like to make `.0` private on `InsertedOrModified` to prevent easy confusion that comes as a result of being able to make the following mistake:

> Jesus it's definitely time for the weekend. I just spend twenty minutes wondering why:
`vm_reference_scope_check.clear_all_inserted_and_modified();`
Wasn't clearing the update pack, when I was checking like this:
`vm_reference_scope_check.inserted_or_modified().0.len()`


To be fair I was also a bit confused, because I've never tried accessing `.0`.

Current world also allows for:
> `vm_reference_scope_check.inserted_or_modified().0.inserted_or_modified().0.inserted_or_modified().0`

What do you all think?
