### PR TITLE
Implement `contains_workload` for `World`

### DIFF
--- a/src/scheduler/mod.rs
+++ b/src/scheduler/mod.rs
@@ -76,6 +76,9 @@ impl Scheduler {
     pub(crate) fn default_workload(&self) -> &Batches {
         &self.workloads[&self.default]
     }
+    pub(crate) fn contains_workload(&self, name: &str) -> bool {
+        self.workloads.contains_key(name)
+    }
     pub(crate) fn is_empty(&self) -> bool {
         self.workloads.is_empty()
     }

--- a/src/world.rs
+++ b/src/world.rs
@@ -669,6 +669,30 @@ let i = world.run(sys1).unwrap();
 
         self.run_batches(&scheduler.systems, &scheduler.system_names, batches)
     }
+    /// Returns `true` if the world contains the `name` workload.
+    ///
+    /// ### Borrows
+    ///
+    /// - Scheduler (shared)
+    ///
+    /// ### Errors
+    ///
+    /// - Scheduler borrow failed.
+    ///
+    /// ### Example
+    /// ```
+    /// use shipyard::{Workload, World};
+    ///
+    /// let world = World::new();
+    ///
+    /// Workload::builder("foo").add_to_world(&world).unwrap();
+    ///
+    /// assert!(world.contains_workload("foo").unwrap());
+    /// assert!(!world.contains_workload("bar").unwrap());
+    /// ```
+    pub fn contains_workload(&self, name: impl AsRef<str>) -> Result<bool, error::Borrow> {
+        Ok(self.scheduler.borrow()?.contains_workload(name.as_ref()))
+    }
     #[allow(clippy::type_complexity)]
     pub(crate) fn run_batches(
         &self,


### PR DESCRIPTION
Hi,
I'm trying to implement a state system for one of my apps that is using `shipyard` and need to check whether a `World` contains a given workload. Currently, this can be done by checking if `set_default_workload` errors out, but obviously, that isn't a great way to do it.

This pull request adds a function that checks if a `World` contains a workload. I didn't add any integration tests because it's a straightforward function, and I think the doc test should be enough. However, if you'd like me to add an integration test, I'd be happy to do it.

Also, on a side note, I noticed this repository runs Clippy on all code submitted, but it doesn't run it with the `--tests` attribute. The `--tests` attribute runs Clippy on tests, and it returned quite a few warnings when I ran it on the repo. Many of them concerned the naming of structs such as `USIZE` that I'm not sure how to handle. If you can give me some guidance on what to do with the names, I'd be happy to fix all the Clippy warnings.