### PR TITLE
parallelism.md: avoid misleading "large storage" wording

### DIFF
--- a/guide/master/src/going-further/parallelism.md
+++ b/guide/master/src/going-further/parallelism.md
@@ -29,4 +29,4 @@ Example:
 {{#include ../../../../tests/book/parallelism.rs:parallelism}}
 ```
 
-Don't replace all your [`iter`](https://docs.rs/shipyard/latest/shipyard/trait.IntoIter.html#tymethod.iter) method calls just yet, however! Using a parallel iterator comes with an upfront overhead cost. It will only exceed the speed of its sequential counterpart on storages large enough to make up for the overhead cost in improved processing efficiency.
+Don't replace all your [`iter`](https://docs.rs/shipyard/latest/shipyard/trait.IntoIter.html#tymethod.iter) method calls just yet, however! Using a parallel iterator comes with an upfront overhead cost. It will only exceed the speed of its sequential counterpart on computations expensive enough to make up for the overhead cost in improved processing efficiency.


### PR DESCRIPTION
Parallelism might be useful even on a view with only two elements, if the computation being done on those elements is lengthy. For example, if I'm iterating over a view of Filenames to compute a hash, then even a small number of elements in the storage can gain a big benefit from parallel iteration.

```rust
use rayon::prelude::*;
use shipyard::{IntoIter, View, ViewMut, World};

#[derive(Debug)]
struct Health(u32);
struct Position {
    x: f32,
    y: f32,
}

fn in_acid(positions: View<Position>, mut healths: ViewMut<Health>) {
    for (_, mut health) in (&positions, &mut healths)
        .iter()
        .filter(|(pos, _)| is_in_acid(pos))
    {
        health.0 -= 1;
    }
}

fn is_in_acid(pos: &Position) -> bool {
    pos.y < 0.5 || pos.x > 1.0
}

fn show_health(healths: View<Health>) {
    // This runs in 2 seconds, not 4, due to parallel iteration
    healths.par_iter().for_each(|h| {
        use std::{thread, time};
        thread::sleep(time::Duration::new(2, 0));
        println!("Health: {:?}", h);
    });
}

fn main() {
    let mut world = World::new();

    world.add_entity((Position { x: 0.0, y: 0.0 }, Health(1000)));
    world.add_entity((Position { x: 1.0, y: 1.0 }, Health(500)));

    world.run(in_acid).unwrap();
    world.run(show_health).unwrap();
}
```