### PR TITLE
fix: Removed delete short-circuiting logic

### DIFF
--- a/src/delete.rs
+++ b/src/delete.rs
@@ -58,7 +58,7 @@ macro_rules! impl_delete_component {
             fn delete(&mut self, entity: EntityId) -> bool {
                 $(
                     self.$index.delete(entity)
-                )||+
+                )|+
             }
         }
     }

--- a/tests/delete.rs
+++ b/tests/delete.rs
@@ -185,3 +185,21 @@ fn track() {
     world.run_default().unwrap();
     world.run_default().unwrap();
 }
+
+#[test]
+fn delete_multiple() {
+    #[derive(PartialEq, Eq, Debug)]
+    struct USIZE(usize);
+    impl Component for USIZE {}
+
+    let mut world = World::new();
+
+    let entity = world.add_entity((USIZE(0), U32(0)));
+
+    world.run(|mut usizes: ViewMut<USIZE>, mut u32s: ViewMut<U32>| {
+        (&mut usizes, &mut u32s).delete(entity);
+
+        assert_eq!(usizes.len(), 0, "First component was not deleted.");
+        assert_eq!(u32s.len(), 0, "Second component was not deleted.");
+    });
+}


### PR DESCRIPTION
It looks like the the impl of `Delete` for tuples joins together the results with `||`, which means that after the first delete succeeds the short-circuiting behaviour prevents any further deletes from actually taking place.

Swapping `||` for `&&` is possibly the least invasive fix that would solve the problem in the expected case, where all views do in fact have an entry for the provided `EntityId`, but I'm not sure I love the idea of any kind of short-circuiting behaviour for `Delete`. For me at least, the most natural assumption is that it will simply try to delete every component from every view that you call it upon. As such, I've simply swapped it out for `|`.

I'm in 2 minds about whether or not I prefer `&` or `|` for the return value, i.e. returning `true` if all vs any components were deleted. Returning a simple bool is perhaps a little less than ideal for the case of multiple deletes, but I guess that's a problem that already exists and I'm not even convinced that I feel over-complicating the return value of `delete` is worth any significant changes.

I've also added a test case which fails on current `master` and passes after this change to hopefully catch this going forwards :smile: 