### PR TITLE
Change tracking value type,from u32 to u64.

### DIFF
--- a/src/all_storages/mod.rs
+++ b/src/all_storages/mod.rs
@@ -33,7 +33,7 @@ use alloc::sync::Arc;
 use core::any::type_name;
 use core::hash::BuildHasherDefault;
 use core::marker::PhantomData;
-use core::sync::atomic::AtomicU32;
+use core::sync::atomic::AtomicU64;
 use hashbrown::hash_map::Entry;
 
 #[allow(missing_docs)]
@@ -103,7 +103,7 @@ impl<Lock, ThreadId> AllStoragesBuilder<Lock, ThreadId> {
 }
 
 impl AllStoragesBuilder<LockPresent, ThreadIdPresent> {
-    pub(crate) fn build(self, counter: Arc<AtomicU32>) -> AtomicRefCell<AllStorages> {
+    pub(crate) fn build(self, counter: Arc<AtomicU64>) -> AtomicRefCell<AllStorages> {
         let mut storages = ShipHashMap::with_hasher(BuildHasherDefault::default());
 
         storages.insert(StorageId::of::<Entities>(), SBox::new(Entities::new()));
@@ -159,7 +159,7 @@ pub struct AllStorages {
     main_thread_id: u64,
     #[cfg(feature = "thread_local")]
     thread_id_generator: Arc<dyn Fn() -> u64 + Send + Sync>,
-    counter: Arc<AtomicU32>,
+    counter: Arc<AtomicU64>,
 }
 
 #[cfg(not(feature = "thread_local"))]
@@ -169,7 +169,7 @@ unsafe impl Sync for AllStorages {}
 
 impl AllStorages {
     #[cfg(feature = "std")]
-    pub(crate) fn new(counter: Arc<AtomicU32>) -> Self {
+    pub(crate) fn new(counter: Arc<AtomicU64>) -> Self {
         let mut storages = ShipHashMap::with_hasher(BuildHasherDefault::default());
 
         storages.insert(StorageId::of::<Entities>(), SBox::new(Entities::new()));

--- a/src/scheduler/into_workload_run_if.rs
+++ b/src/scheduler/into_workload_run_if.rs
@@ -9,7 +9,7 @@ use crate::World;
 use alloc::boxed::Box;
 use alloc::sync::Arc;
 use alloc::vec::Vec;
-use core::sync::atomic::{AtomicU32, Ordering};
+use core::sync::atomic::{AtomicU64, Ordering};
 
 pub trait IntoRunIf<B> {
     fn into_workload_run_if(self) -> Result<RunIf, error::InvalidSystem>;
@@ -80,7 +80,7 @@ macro_rules! impl_into_workload_run_if {
                     }
                 }
 
-                let last_run = AtomicU32::new(0);
+                let last_run = AtomicU64::new(0);
                 Ok(RunIf {
                     system_fn: Box::new(move |world: &World| {
                         let current = world.get_current();
@@ -165,7 +165,7 @@ macro_rules! impl_into_workload_run_if {
                     }
                 }
 
-                let last_run = Arc::new(AtomicU32::new(0));
+                let last_run = Arc::new(AtomicU64::new(0));
                 Ok(Box::new(move |world: &World| {
                     let current = world.get_current();
                     let last_run = TrackingTimestamp::new(last_run.swap(current.get(), Ordering::Acquire));

--- a/src/scheduler/into_workload_system.rs
+++ b/src/scheduler/into_workload_system.rs
@@ -12,7 +12,7 @@ use alloc::boxed::Box;
 use alloc::vec;
 use alloc::vec::Vec;
 use core::any::type_name;
-use core::sync::atomic::{AtomicU32, Ordering};
+use core::sync::atomic::{AtomicU64, Ordering};
 
 /// Trait used to add systems to a workload.
 ///
@@ -145,7 +145,7 @@ macro_rules! impl_into_workload_system {
                     $type::enable_tracking(&mut tracking_to_enable);
                 )+
 
-                let last_run = AtomicU32::new(0);
+                let last_run = AtomicU64::new(0);
                 Ok(WorkloadSystem {
                     borrow_constraints: borrows,
                     tracking_to_enable,

--- a/src/scheduler/into_workload_try_system.rs
+++ b/src/scheduler/into_workload_try_system.rs
@@ -15,7 +15,7 @@ use alloc::vec::Vec;
 use core::any::type_name;
 #[cfg(not(feature = "std"))]
 use core::any::Any;
-use core::sync::atomic::{AtomicU32, Ordering};
+use core::sync::atomic::{AtomicU64, Ordering};
 #[cfg(feature = "std")]
 use std::error::Error;
 
@@ -179,7 +179,7 @@ macro_rules! impl_into_workload_try_system {
                     $type::enable_tracking(&mut tracking_to_enable);
                 )+
 
-                let last_run = AtomicU32::new(0);
+                let last_run = AtomicU64::new(0);
                 Ok(WorkloadSystem {
                     borrow_constraints: borrows,
                     tracking_to_enable,
@@ -250,7 +250,7 @@ macro_rules! impl_into_workload_try_system {
                     $type::enable_tracking(&mut tracking_to_enable);
                 )+
 
-                let last_run = AtomicU32::new(0);
+                let last_run = AtomicU64::new(0);
                 Ok(WorkloadSystem {
                     borrow_constraints: borrows,
                     tracking_to_enable,

--- a/src/tracking.rs
+++ b/src/tracking.rs
@@ -182,17 +182,17 @@ pub(crate) fn map_deletion_data<T>(
 
 /// Timestamp used to clear tracking information.
 #[derive(Clone, Copy, Debug)]
-pub struct TrackingTimestamp(u32);
+pub struct TrackingTimestamp(u64);
 
 impl TrackingTimestamp {
     /// Returns a new [`TrackingTimestamp`] at the given tracking cycle.
     #[inline]
-    pub fn new(now: u32) -> TrackingTimestamp {
+    pub fn new(now: u64) -> TrackingTimestamp {
         TrackingTimestamp(now)
     }
 
     #[inline]
-    pub(crate) fn get(self) -> u32 {
+    pub(crate) fn get(self) -> u64 {
         self.0
     }
 
@@ -212,13 +212,13 @@ impl TrackingTimestamp {
     /// This method should only be necessary for custom storages that want to implement tracking.
     #[inline]
     pub fn is_older_than(self, other: TrackingTimestamp) -> bool {
-        other.0.wrapping_sub(1).wrapping_sub(self.0) < u32::MAX / 2
+        other.0.wrapping_sub(1).wrapping_sub(self.0) < u64::MAX / 2
     }
 
     /// Returns the timesptamp the furthest from the given one.
     #[inline]
     pub fn furthest_from(self) -> TrackingTimestamp {
-        TrackingTimestamp(self.0.wrapping_add(u32::MAX / 2))
+        TrackingTimestamp(self.0.wrapping_add(u64::MAX / 2))
     }
 }
 
@@ -233,9 +233,9 @@ mod tests {
             (5, 0, 10, true),
             (11, 0, 10, false),
             // check wrapping true
-            (u32::MAX, u32::MAX - 1, 0, true),
+            (u64::MAX, u64::MAX - 1, 0, true),
             // check wrapping false
-            (u32::MAX - 1, u32::MAX, 0, false),
+            (u64::MAX - 1, u64::MAX, 0, false),
             (1, 2, 0, false),
             // timestamp is equal to last
             (1, 1, 0, false),
@@ -262,13 +262,13 @@ mod tests {
             (5, 10, true),
             (11, 10, false),
             // check wrapping true
-            (u32::MAX, 0, true),
+            (u64::MAX, 0, true),
             // check wrapping false
-            (0, u32::MAX, false),
+            (0, u64::MAX, false),
             // barely within limit
-            (0, u32::MAX / 2, true),
+            (0, u64::MAX / 2, true),
             // barely outside limit
-            (0, u32::MAX / 2 + 1, false),
+            (0, u64::MAX / 2 + 1, false),
             // timestamp is equal to other
             (1, 1, false),
         ];

--- a/src/world.rs
+++ b/src/world.rs
@@ -27,13 +27,13 @@ use crate::views::EntitiesViewMut;
 use alloc::boxed::Box;
 use alloc::format;
 use alloc::sync::Arc;
-use core::sync::atomic::AtomicU32;
+use core::sync::atomic::AtomicU64;
 
 /// `World` contains all data this library will manipulate.
 pub struct World {
     pub(crate) all_storages: AtomicRefCell<AllStorages>,
     pub(crate) scheduler: AtomicRefCell<Scheduler>,
-    counter: Arc<AtomicU32>,
+    counter: Arc<AtomicU64>,
     #[cfg(feature = "parallel")]
     thread_pool: Option<rayon::ThreadPool>,
 }
@@ -42,7 +42,7 @@ pub struct World {
 impl Default for World {
     /// Creates an empty `World`.
     fn default() -> Self {
-        let counter = Arc::new(AtomicU32::new(1));
+        let counter = Arc::new(AtomicU64::new(1));
         World {
             #[cfg(not(feature = "thread_local"))]
             all_storages: AtomicRefCell::new(AllStorages::new(counter.clone())),

--- a/src/world/builder.rs
+++ b/src/world/builder.rs
@@ -3,7 +3,7 @@ use crate::atomic_refcell::AtomicRefCell;
 use crate::public_transport::ShipyardRwLock;
 use crate::world::World;
 use alloc::sync::Arc;
-use core::sync::atomic::AtomicU32;
+use core::sync::atomic::AtomicU64;
 
 /// Builder for [`World`] when one wants custom lock, custom thread pool
 /// or custom thread id provider function.
@@ -105,7 +105,7 @@ impl<Lock, ThreadId> WorldBuilder<Lock, ThreadId> {
 impl WorldBuilder<LockPresent, ThreadIdPresent> {
     /// Creates a new [`World`] based on the [`WorldBuilder`] config.
     pub fn build(self) -> World {
-        let counter = Arc::new(AtomicU32::new(1));
+        let counter = Arc::new(AtomicU64::new(1));
 
         let all_storages = self.all_storages_builder.build(counter.clone());
 


### PR DESCRIPTION
This PR is submitted to mitigate the issues in issue #190.
My project is suffering from a bug that is believed to be caused by this.
In most cases, changing from u32 to u64 will not be a significant drawback, and conversely, there will be few cases where it is absolutely necessary, so I will defer to the maintainer's decision.

`cargo test` and `cargo make test` done.
ps. is `cargo make test-all` still valid?