### PR TITLE
Fix private_clear: Extend removal_data & clear modification_data

### DIFF
--- a/src/sparse_set/mod.rs
+++ b/src/sparse_set/mod.rs
@@ -612,15 +612,10 @@ impl<T: Component> SparseSet<T> {
         self.insertion_data.clear();
         self.modification_data.clear();
 
-        let is_tracking_deletion = self.is_tracking_deletion();
-        let is_tracking_removal = self.is_tracking_removal();
-
         let dense = self.dense.drain(..);
         let data = self.data.drain(..);
 
-        if is_tracking_removal {
-            self.removal_data.extend(dense.as_ref().into_iter().map(|entity| (*entity, current)));
-        }
+        let is_tracking_deletion = self.is_tracking_deletion();
         if is_tracking_deletion {
             let iter = dense
                 .zip(data)

--- a/src/sparse_set/mod.rs
+++ b/src/sparse_set/mod.rs
@@ -610,16 +610,21 @@ impl<T: Component> SparseSet<T> {
         }
 
         self.insertion_data.clear();
+        self.modification_data.clear();
 
         let is_tracking_deletion = self.is_tracking_deletion();
+        let is_tracking_removal = self.is_tracking_removal();
 
-        let iter = self
-            .dense
-            .drain(..)
-            .zip(self.data.drain(..))
-            .map(|(entity, component)| (entity, current, component));
+        let dense = self.dense.drain(..);
+        let data = self.data.drain(..);
 
+        if is_tracking_removal {
+            self.removal_data.extend(dense.as_ref().into_iter().map(|entity| (*entity, current)));
+        }
         if is_tracking_deletion {
+            let iter = dense
+                .zip(data)
+                .map(|(entity, component)| (entity, current, component));
             self.deletion_data.extend(iter);
         }
     }


### PR DESCRIPTION
I noticed the original code didn’t clear modification_data and did not extend removal_data. Was that intentional, or should we address it here?