### PR TITLE
Fix tracking data memory leak

### DIFF
--- a/src/sparse_set/mod.rs
+++ b/src/sparse_set/mod.rs
@@ -1234,6 +1234,7 @@ mod tests {
 
         assert_eq!(sparse_set.len(), 0);
         assert_eq!(sparse_set.private_get(EntityId::new(0)), None);
+        assert_eq!(sparse_set.private_get(EntityId::new(1)), None);
         assert_eq!(sparse_set.insertion_data.len(), 0);
         assert_eq!(sparse_set.modification_data.len(), 0);
         assert_eq!(sparse_set.deletion_data.len(), 2);
@@ -1262,6 +1263,7 @@ mod tests {
 
         assert_eq!(sparse_set.len(), 0);
         assert_eq!(sparse_set.private_get(EntityId::new(0)), None);
+        assert_eq!(sparse_set.private_get(EntityId::new(1)), None);
         assert_eq!(sparse_set.insertion_data.len(), 0);
         assert_eq!(sparse_set.modification_data.len(), 0);
         assert_eq!(sparse_set.deletion_data.len(), 0);


### PR DESCRIPTION
- Add clear insertion & modification in private_drain
- Add clear modification in private_clear
- Add test cases related to tracking

I think I spotted the same issue in the private_drain function and fixed it—does that seem right? While fixing, I also included the changes from version 0.7. If it causes any merge conflicts, feel free to drop them