### PR TITLE
Add public visibility to generated item types in expand_into_iter

### DIFF
--- a/shipyard_proc/src/into_iter_expand.rs
+++ b/shipyard_proc/src/into_iter_expand.rs
@@ -156,7 +156,7 @@ pub(crate) fn expand_into_iter(
                                 field_name.span(),
                             )
                         });
-                        let item_ty = parse_quote!(#trimmed_field_name: <<&'__tmp shipyard::View<'__view, #comp_ty, #tracking_ty> as shipyard::iter::IntoShiperator>::Shiperator as shipyard::iter::ShiperatorOutput>::Out);
+                        let item_ty = parse_quote!(pub #trimmed_field_name: <<&'__tmp shipyard::View<'__view, #comp_ty, #tracking_ty> as shipyard::iter::IntoShiperator>::Shiperator as shipyard::iter::ShiperatorOutput>::Out);
                         item_fields.push(item_ty);
 
                         let abstract_view_ty =
@@ -209,7 +209,7 @@ pub(crate) fn expand_into_iter(
                                 field_name.span(),
                             )
                         });
-                        let item_ty = parse_quote!(#trimmed_field_name: <<&'__tmp mut shipyard::ViewMut<'__view, #comp_ty, #tracking_ty> as shipyard::iter::IntoShiperator>::Shiperator as shipyard::iter::ShiperatorOutput>::Out);
+                        let item_ty = parse_quote!(pub #trimmed_field_name: <<&'__tmp mut shipyard::ViewMut<'__view, #comp_ty, #tracking_ty> as shipyard::iter::IntoShiperator>::Shiperator as shipyard::iter::ShiperatorOutput>::Out);
                         item_fields.push(item_ty);
 
                         let abtract_view_ty = parse_quote!(&'__tmp mut shipyard::ViewMut<'__view, #comp_ty, #tracking_ty>);

--- a/shipyard_proc/src/into_iter_expand.rs
+++ b/shipyard_proc/src/into_iter_expand.rs
@@ -141,6 +141,7 @@ pub(crate) fn expand_into_iter(
 
                         let tracking_ty = tys.next();
 
+                        let field_vis = field.vis.clone();
                         let field_name = field.ident.clone().unwrap();
                         let trimmed_field_name = field_name_override.unwrap_or_else(|| {
                             let field_name = field.ident.as_ref().unwrap();
@@ -156,7 +157,7 @@ pub(crate) fn expand_into_iter(
                                 field_name.span(),
                             )
                         });
-                        let item_ty = parse_quote!(pub #trimmed_field_name: <<&'__tmp shipyard::View<'__view, #comp_ty, #tracking_ty> as shipyard::iter::IntoShiperator>::Shiperator as shipyard::iter::ShiperatorOutput>::Out);
+                        let item_ty = parse_quote!(#field_vis #trimmed_field_name: <<&'__tmp shipyard::View<'__view, #comp_ty, #tracking_ty> as shipyard::iter::IntoShiperator>::Shiperator as shipyard::iter::ShiperatorOutput>::Out);
                         item_fields.push(item_ty);
 
                         let abstract_view_ty =
@@ -194,6 +195,7 @@ pub(crate) fn expand_into_iter(
 
                         let tracking_ty = tys.next();
 
+                        let field_vis = field.vis.clone();
                         let field_name = field.ident.clone().unwrap();
                         let trimmed_field_name = field_name_override.unwrap_or_else(|| {
                             let field_name = field.ident.as_ref().unwrap();
@@ -209,7 +211,7 @@ pub(crate) fn expand_into_iter(
                                 field_name.span(),
                             )
                         });
-                        let item_ty = parse_quote!(pub #trimmed_field_name: <<&'__tmp mut shipyard::ViewMut<'__view, #comp_ty, #tracking_ty> as shipyard::iter::IntoShiperator>::Shiperator as shipyard::iter::ShiperatorOutput>::Out);
+                        let item_ty = parse_quote!(#field_vis #trimmed_field_name: <<&'__tmp mut shipyard::ViewMut<'__view, #comp_ty, #tracking_ty> as shipyard::iter::IntoShiperator>::Shiperator as shipyard::iter::ShiperatorOutput>::Out);
                         item_fields.push(item_ty);
 
                         let abtract_view_ty = parse_quote!(&'__tmp mut shipyard::ViewMut<'__view, #comp_ty, #tracking_ty>);

--- a/tests/derive/mod.rs
+++ b/tests/derive/mod.rs
@@ -92,3 +92,39 @@ fn into_iter_rename() {
         }
     });
 }
+
+/// Checks that field visibility applies to the generated iterator.
+#[test]
+fn into_iter_field_visibility() {
+    mod inner {
+        use super::*;
+
+        #[derive(Component)]
+        pub struct A;
+
+        #[derive(Component)]
+        pub struct B;
+
+        #[derive(IntoIter, Borrow)]
+        pub struct CustomView<'a> {
+            pub(super) comp_a: shipyard::View<'a, A>,
+            pub(crate) v_comp_aa: shipyard::View<'a, A>,
+            pub comp_b: shipyard::ViewMut<'a, B>,
+            vm_comp_bb: shipyard::ViewMut<'a, B>,
+        }
+    }
+
+    let world = World::new();
+    let Ok(view) = world.borrow::<inner::CustomView>() else {
+        // This function always returns here since 2 ViewMut cannot be borrowed
+        // This test is only a compile check, not runtime
+
+        return;
+    };
+
+    view.comp_a;
+    view.comp_b;
+    view.v_comp_aa;
+    // Should not be accessible
+    // view.v_comp_bb;
+}


### PR DESCRIPTION
I missed the fields when I added the struct-level visibility in #232.  This rectifies that oversight.

I'm pretty sure it's appropriate that the fields are `pub` and that the generated `Iter` structs share the visibility.