### PR TITLE
Add with_id to parallel iterators

### DIFF
--- a/src/iter/parallel.rs
+++ b/src/iter/parallel.rs
@@ -1,7 +1,15 @@
-use crate::iter::{Shiperator, ShiperatorCaptain, ShiperatorSailor};
+use crate::entity_id::EntityId;
+use crate::iter::{Shiperator, ShiperatorCaptain, ShiperatorSailor, WithId};
 
 #[allow(missing_docs)]
 pub struct ParShiperator<S>(pub(crate) Shiperator<S>);
+
+impl<S> ParShiperator<S> {
+    /// Returns the [`EntityId`] alongside the component(s).
+    pub fn with_id(self) -> WithId<Self> {
+        WithId(self)
+    }
+}
 
 impl<S: ShiperatorCaptain + ShiperatorSailor + Send + Clone>
     rayon::iter::plumbing::UnindexedProducer for Shiperator<S>
@@ -44,6 +52,24 @@ impl<S: ShiperatorCaptain + ShiperatorSailor + Send + Clone>
         F: rayon::iter::plumbing::Folder<Self::Item>,
     {
         folder.consume_iter(self)
+    }
+}
+
+impl<S: ShiperatorCaptain + ShiperatorSailor + Send + Clone> rayon::iter::ParallelIterator
+    for WithId<ParShiperator<S>>
+where
+    S::Out: Send,
+{
+    type Item = (EntityId, S::Out);
+
+    #[inline]
+    fn drive_unindexed<C>(self, consumer: C) -> C::Result
+    where
+        C: rayon::iter::plumbing::UnindexedConsumer<Self::Item>,
+    {
+        let WithId(ParShiperator(producer)) = self;
+
+        rayon::iter::plumbing::bridge_unindexed(WithId(producer), consumer)
     }
 }
 

--- a/tests/key.rs
+++ b/tests/key.rs
@@ -12,6 +12,13 @@ impl Component for U32 {
     type Tracking = track::Untracked;
 }
 
+#[cfg(feature = "parallel")]
+struct Tracked(usize);
+#[cfg(feature = "parallel")]
+impl Component for Tracked {
+    type Tracking = track::All;
+}
+
 #[test]
 fn key_equality() {
     let world = World::new();
@@ -60,5 +67,75 @@ fn key_equality() {
 
         let (entity, (_, _)) = (&usizes, &u32s).iter().with_id().find(|_| true).unwrap();
         assert_eq!(entity, e1);
+    });
+}
+
+#[cfg(feature = "parallel")]
+#[test]
+fn parallel_with_id_keeps_entity_alignment() {
+    use core::sync::atomic::{AtomicUsize, Ordering};
+    use rayon::prelude::*;
+
+    let mut world = World::new();
+    let ids = (0..300)
+        .map(|i| {
+            if i % 2 == 0 {
+                world.add_entity((USIZE(i), U32(i as u32), Tracked(i)))
+            } else {
+                world.add_entity((USIZE(i), Tracked(i)))
+            }
+        })
+        .collect::<Vec<_>>();
+    world.clear_all_inserted_and_modified();
+    world.run(|_tracked: ViewMut<Tracked, track::All>| {});
+
+    world.run(|usizes: View<USIZE>| {
+        let mut actual = (&usizes)
+            .par_iter()
+            .with_id()
+            .map(|(id, value)| (id, value.0))
+            .collect::<Vec<_>>();
+        actual.sort_unstable_by_key(|(_, value)| *value);
+
+        assert_eq!(actual, ids.iter().copied().zip(0..300).collect::<Vec<_>>());
+    });
+
+    world.run(|(usizes, u32s): (View<USIZE>, View<U32>)| {
+        (&usizes, &u32s)
+            .par_iter()
+            .with_id()
+            .for_each(|(id, (usize, u32))| {
+                assert_eq!(id, ids[usize.0]);
+                assert_eq!(u32.0, usize.0 as u32);
+            });
+    });
+
+    world.run(|mut usizes: ViewMut<USIZE>| {
+        (&mut usizes).par_iter().with_id().for_each(|(id, value)| {
+            assert_eq!(id, ids[value.0]);
+            value.0 += 1;
+        });
+    });
+
+    world.run(|mut tracked: ViewMut<Tracked, track::All>| {
+        for &index in &[5usize, 70, 200, 299] {
+            let mut value = (&mut tracked).get(ids[index]).unwrap();
+            value.0 = index;
+        }
+    });
+
+    world.run(|tracked: ViewMut<Tracked, track::All>| {
+        let hits = AtomicUsize::new(0);
+
+        tracked
+            .modified()
+            .par_iter()
+            .with_id()
+            .for_each(|(id, value)| {
+                assert_eq!(id, ids[value.0]);
+                hits.fetch_add(1, Ordering::Relaxed);
+            });
+
+        assert_eq!(hits.load(Ordering::Relaxed), 4);
     });
 }


### PR DESCRIPTION
Related issue : #191 

- Add `ParShiperator::with_id()` by reusing the existing `WithId<Shiperator<_>>` producer.
- Preserve `(EntityId, (components...))` for views, joins, mutable views, and tracking queries.
- Keep `opt_len()` unspecified to avoid Rayon selecting an indexed consumer during parallel collection.

On a personal note, I tried to implement this before the Shiperator refactor, but couldn't find a clean approach. Revisiting it afterward made the change surprisingly straightforward. Thank you for the redesign 👍 